### PR TITLE
Feat: Object Manipulation Components and Hooks

### DIFF
--- a/app/(components)/Shared/Manipulation/ManipulationContainer.tsx
+++ b/app/(components)/Shared/Manipulation/ManipulationContainer.tsx
@@ -1,0 +1,46 @@
+import useContextHandler from '@/hooks/Shared/Context/useContextHandler'
+import BaseProps from '@/typings/BaseProps'
+import ReactState from '@/typings/ReactState'
+import { createContext } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+interface ContextProps<T> {
+  object: ReactState<T>['state']
+  setObject: ReactState<T>['setState']
+  debounce: number
+}
+const Context = createContext<ContextProps<any> | null>(null)
+
+/**
+ *
+ * @returns The context of the ManipulationContainer that holds the object and its setState-function
+ */
+export let useManipulationProvider = <T,>() => useContextHandler<ContextProps<T>>(Context)
+
+/**
+ * Accepts the state of an object that is then used by its children (Input) to manipulate the object
+ * @param object The useState-object that should be manipulated
+ * @param setObeject The setState-function that should be used to update the object
+ * @param className The className that should be applied to the container
+ * @param debounce The time in ms that the input elements should wait before updating the object
+ * @returns The container that holds the Input-elements that manipulate the given object
+ */
+export default function ManipulationContainter<T>({
+  object,
+  setObject,
+  children,
+  className,
+  debounce,
+}: {
+  object: ReactState<T>['state']
+  setObject: ReactState<T>['setState']
+  children?: BaseProps['children']
+  className?: string
+  debounce?: number
+}) {
+  return (
+    <Context.Provider value={{ object, setObject, debounce: debounce ?? 0 }}>
+      <div className={twMerge('flex flex-wrap gap-2', className)}>{children}</div>
+    </Context.Provider>
+  )
+}

--- a/app/(components)/Shared/Manipulation/ManipulationInput.tsx
+++ b/app/(components)/Shared/Manipulation/ManipulationInput.tsx
@@ -1,0 +1,133 @@
+import ObjectPath from '@/typings/ObjectPath'
+import React, { InputHTMLAttributes, useEffect, useState } from 'react'
+import { useManipulationProvider } from './ManipulationContainer'
+
+interface ManipulationInputProps<MainObj> {
+  label?: string
+  path: ObjectPath<MainObj>
+}
+
+/**
+ * Renders an input element that updates the given property of the object in the manipulation context
+ * @param label The label that is displayed next to the input, default the property name
+ * @param path The path to the property that should be updated and displayed
+ * @returns
+ */
+export function ManipulationInput<MainObj>({ label, path }: ManipulationInputProps<MainObj>) {
+  const { object: main, setObject, debounce } = useManipulationProvider<MainObj>()
+  const [_internal, _setInteral] = useState<MainObj>(main)
+
+  //* Debounce the object update
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setObject(_internal)
+    }, debounce ?? 0)
+
+    return () => clearTimeout(timeout)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [_internal])
+
+  //* Get the current value of the requested property
+  //@ts-ignore
+  const defaultValue = path.split('.').reduce((acc, curr) => acc[curr], main)
+
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    let value: string | number | boolean = defaultValue!.toString()
+
+    switch (typeof defaultValue) {
+      case 'boolean':
+        value = e.target.checked
+        break
+      case 'string':
+        value = e.target.value.toString()
+        break
+      case 'number':
+        value = parseFloat(e.target.value)
+        break
+      default:
+        console.log('Changed property expects a non-primitve type... discarding changes.')
+        return
+    }
+
+    _setInteral(updateObjectByPath(main, path, value))
+  }
+
+  const inputType = (): InputHTMLAttributes<HTMLInputElement>['type'] => {
+    switch (typeof defaultValue) {
+      case 'boolean':
+        return 'checkbox'
+      case 'number':
+        return 'number'
+      default:
+        return 'text'
+    }
+  }
+
+  return (
+    <div className='flex max-w-fit items-center gap-4 rounded-md bg-neutral-700 px-3 py-1.5'>
+      <label className='text-lg' htmlFor={path.toString()}>
+        {label ?? path?.split('.')?.at(-1)?.toString() ?? path}:
+      </label>
+
+      <input type={inputType()} className='rounded-md dark:bg-neutral-700/40 ' id={path.toString()} onChange={onChange} defaultValue={String(defaultValue)} />
+    </div>
+  )
+}
+
+function updateObjectByPath<T>(obj: object | T, path: ObjectPath<T> | string, value: any): T {
+  if (path.split('.').length === 1 || !path.includes('.')) {
+    return Object.assign({}, obj, { [path]: value }) as T
+  } else {
+    // Nested property update
+    const [first, ...rest] = path.split('.')
+    return {
+      ...obj,
+      // @ts-ignore
+      [first]: updateObjectByPath(obj[first], rest.join('.'), value),
+    } as T
+  }
+}
+
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+// Usage example with a nested object type
+type MyObjectType = {
+  isCanceled: boolean
+  customer: {
+    firstName: string
+    lastName: string
+    address: {
+      street: string
+      city: string
+      zip: {
+        house: number
+        test: {
+          something: string
+        }
+      }
+    }
+  }
+}
+
+// // This type will allow any valid deep path within MyObjectType
+// type MyObjectPath = DeepPath<MyObjectType, keyof MyObjectType>
+
+// Example of valid paths
+const path1: ObjectPath<MyObjectType> = 'isCanceled' // Top-level property
+const path2: ObjectPath<MyObjectType> = 'customer.firstName' // Nested property
+const path3: ObjectPath<MyObjectType> = 'customer.address.street' // More deeply nested property
+
+const path4: ObjectPath<MyObjectType> = 'customer.address.zip.house'
+const path5: ObjectPath<MyObjectType> = 'customer.address.zip.test.something'

--- a/app/(components)/Shared/Manipulation/useManipulation.tsx
+++ b/app/(components)/Shared/Manipulation/useManipulation.tsx
@@ -7,6 +7,20 @@ import { ManipulationInput } from './ManipulationInput'
  * @param object The useState-object that should be manipulated
  * @param setObject The setState-function that should be used to update the object
  * @returns The container and input components that are used to manipulate the given object
+ * 
+ * @example
+ * ```tsx
+ * const { Container, Input, containerProps } = useManipulation({ object, setObject })
+ * <Container {...containerProps}>
+    <Input label='Custom-Label' path='isCanceled' />
+
+    <Input path='customer.firstName' />
+    <Input path='customer.lastName' />
+    <Input path='customer.lastName' />
+    <Input path='customer.country' />
+   </Container>
+ * 
+ * ```
  */
 export default function useManipulation<T>({ object, setObject }: { object: ReactState<T>['state']; setObject: ReactState<T>['setState'] }) {
   return {

--- a/app/(components)/Shared/Manipulation/useManipulation.tsx
+++ b/app/(components)/Shared/Manipulation/useManipulation.tsx
@@ -1,0 +1,17 @@
+import ReactState from '@/typings/ReactState'
+import ManipulationContainter from './ManipulationContainer'
+import { ManipulationInput } from './ManipulationInput'
+
+/**
+ * This hook returns the container and input components that are used to manipulate an object and unifies the type of object between these components
+ * @param object The useState-object that should be manipulated
+ * @param setObject The setState-function that should be used to update the object
+ * @returns The container and input components that are used to manipulate the given object
+ */
+export default function useManipulation<T>({ object, setObject }: { object: ReactState<T>['state']; setObject: ReactState<T>['setState'] }) {
+  return {
+    containerProps: { object, setObject },
+    Container: ManipulationContainter<T>,
+    Input: ManipulationInput<T>,
+  }
+}

--- a/hooks/Shared/Context/useContextHandler.ts
+++ b/hooks/Shared/Context/useContextHandler.ts
@@ -1,0 +1,14 @@
+'use client'
+import { Context, useContext } from 'react'
+
+/**
+ * Checks whether the requested context is valid and returns the context if it is
+ * @param _context The requested context
+ * @returns Depending on the validity of the context it returns the context-props or throws an error
+ */
+export default function useContextHandler<Props>(_context: Context<Props | null>): Props {
+  const context = useContext(_context)
+  if (!context) throw new Error('useContextHandler can only be used within the requested Context-Provider!')
+
+  return context as Props
+}

--- a/typings/ObjectPath.ts
+++ b/typings/ObjectPath.ts
@@ -1,0 +1,27 @@
+type NonOptional<T, K extends keyof T> = K extends string
+  ? T[K] extends Record<string, any>
+    ? // If it's a nested object, recurse into it
+      K | `${K}.${NonOptional<T[K], keyof T[K]>}`
+    : // If it's not an object, just return the key
+      K
+  : never
+
+// Also includes the functions that are exposed by the Date objects...
+type DeepPathAllOptionals<T, K extends keyof T> = K extends string
+  ? T[K] extends Record<string, any> | undefined
+    ? K | `${K}.${DeepPath<NonNullable<T[K]>, keyof NonNullable<T[K]>>}` | `${K}?`
+    : K
+  : never
+
+type ExcludeTypes = Array<any> | Date | Set<any> | Map<any, any>
+type DeepPath<T, K extends keyof T> = K extends string
+  ? T[K] extends Record<string, any> | undefined
+    ? T[K] extends ExcludeTypes
+      ? never // Exclude this path if it matches the excluded types
+      : K | `${K}.${DeepPath<NonNullable<T[K]>, keyof NonNullable<T[K]>>}`
+    : K
+  : never
+
+type ObjectPath<T> = DeepPath<T, keyof T>
+
+export default ObjectPath


### PR DESCRIPTION
The following changes were made in this Pull request:
- created `ObjectPath`, that makes the property-path of a object type-safe
- created `useContextHandler` hook, that checks the validity of a context and either returns its props or throws an error
- created `ManipuationContainer` component, that accepts the state of a given object and exposes it via a Context the Input elements that it wraps.
- created `ManipulationInput` component, that allows users to modify a given property of the object. Automatically changes the objects-properties value either instantly or after the specified debounce-time (set by the debounce property of the Container.
- created `useManipulation` hook, this hook accepts the useState values for a given object and returns the Container and Input element with the same type of the object, to ensure type-safety. 