### PR TITLE
Style: Added Styles to support the Light-Colormode

### DIFF
--- a/app/(components)/Shared/Manipulation/ManipulationInput.tsx
+++ b/app/(components)/Shared/Manipulation/ManipulationInput.tsx
@@ -73,11 +73,11 @@ export function ManipulationInput<T>({ label, path, hidden, containerClassName, 
   }
 
   return (
-    <div className={twMerge('flex items-center gap-6 rounded-md bg-neutral-700 px-3 py-1.5', containerClassName)}>
-      <label className={twMerge('relative text-lg dark:text-gray-200', labelClassName)} htmlFor={path.toString()}>
+    <div className={twMerge('flex items-center gap-6 rounded-md bg-neutral-200 px-3 py-1.5 dark:bg-neutral-700', containerClassName)}>
+      <label className={twMerge('relative text-lg text-gray-600 dark:text-gray-200', labelClassName)} htmlFor={path.toString()}>
         {label ?? path?.split('.')?.at(-1)?.toString() ?? path}
         {inputProps.required && (
-          <span className='absolute -right-2 -top-1 text-sm dark:text-red-300' title='required'>
+          <span className='absolute -right-2 -top-1 text-sm text-red-400 dark:text-red-300' title='required'>
             *
           </span>
         )}
@@ -89,9 +89,10 @@ export function ManipulationInput<T>({ label, path, hidden, containerClassName, 
         type={inputType()}
         {...inputProps}
         className={twMerge(
-          'dark:text-gray-300',
-          'min-w-4 flex-1 rounded-md dark:bg-neutral-700/40 dark:placeholder:text-gray-300/40',
-          'invalid:border-red-400 invalid:ring-1 invalid:ring-red-400',
+          'text-gray-500 dark:text-gray-300 ',
+          'border-gray-400 focus:border-blue-600 dark:border-gray-500 dark:focus:border-blue-600',
+          'min-w-4 flex-1 rounded-md bg-neutral-300/80 placeholder:text-white/70 dark:bg-neutral-700/40 dark:placeholder:text-gray-300/40',
+          'invalid:border-red-400 invalid:ring-1 invalid:ring-red-400 dark:invalid:border-red-400 dark:invalid:ring-red-400',
           inputProps.type === 'radio' ? 'max-w-4 checked:border-gray-700 checked:bg-blue-600 dark:checked:border-gray-400 checked:dark:bg-blue-600 ' : null,
           inputClassName,
         )}

--- a/app/(components)/Shared/Slideover/SlideOver.tsx
+++ b/app/(components)/Shared/Slideover/SlideOver.tsx
@@ -30,8 +30,8 @@ export default function SlideOver({ title, maxWidth, children }: SlideOverProps)
                 leaveTo='translate-y-full sm:translate-y-0 sm:translate-x-full'>
                 <Dialog.Panel className={twMerge('pointer-events-auto max-w-md', maxWidth)}>
                   <div className='flex h-full flex-col overflow-y-auto overflow-x-hidden overscroll-none scroll-smooth bg-gray-100 shadow-md shadow-gray-400 dark:bg-neutral-800 dark:shadow-neutral-700'>
-                    <div className='sticky right-0 top-0 z-10 mb-4 flex w-full items-center justify-between border-b-2 border-neutral-300 px-4 py-2 pb-2 dark:border-b-neutral-700 dark:bg-neutral-800'>
-                      <h2 className='text-xl font-semibold text-gray-500 dark:text-gray-200'>{title}</h2>
+                    <div className='sticky right-0 top-0 z-10 mb-4 flex w-full items-center justify-between border-b-2 border-neutral-600 bg-neutral-200 px-4 py-2 pb-2 dark:border-neutral-300 dark:border-b-neutral-700 dark:bg-neutral-800'>
+                      <h2 className='text-xl font-semibold text-gray-700 dark:text-gray-200'>{title}</h2>
                       <button
                         type='button'
                         className='relative rounded-md bg-gray-100/50 text-gray-400 ring-2 ring-transparent hover:text-gray-500 hover:ring-gray-300 dark:bg-neutral-700/40 dark:hover:text-gray-300 dark:hover:ring-neutral-700 dark:active:ring-gray-400'

--- a/app/(components)/orders/CustomerRegistrationMenu.tsx
+++ b/app/(components)/orders/CustomerRegistrationMenu.tsx
@@ -18,11 +18,13 @@ export default function CustomerRegistrationMenu() {
       <div className='flex flex-1 flex-col gap-4 overflow-y-auto px-4 pb-4'>
         <CustomerProps key={order?.id + baseInformation} />
       </div>
-      <div className='mt-4 flex justify-center gap-4 border-t-2 px-4 py-4 dark:border-t-neutral-700'>
-        <button className='rounded-md px-4 py-2 ring-1 dark:text-gray-300/90 dark:ring-gray-400/60' onClick={close} type='button'>
+      <div className='mt-4 flex justify-center gap-4 border-t-2 border-t-neutral-500 px-4 py-4 dark:border-t-neutral-700'>
+        <button className='rounded-md px-4 py-2 text-gray-600 ring-1 ring-gray-400 dark:text-gray-300/90 dark:ring-gray-400/60' onClick={close} type='button'>
           Close Menu
         </button>
-        <button className='rounded-md px-4 py-2 dark:bg-green-500/40 dark:text-gray-300 dark:hover:bg-green-500/60 dark:hover:text-gray-200 dark:active:bg-green-500/70' type='submit'>
+        <button
+          className='rounded-md bg-green-500/40 px-4 py-2 text-gray-600 hover:bg-green-500/50 active:bg-green-500/70 dark:bg-green-500/40 dark:text-gray-300 dark:hover:bg-green-500/60 dark:hover:text-gray-200 dark:active:bg-green-500/70'
+          type='submit'>
           Kunde Anlegen
         </button>
       </div>
@@ -89,8 +91,8 @@ function CustomerProps() {
       <Input label='Tel' path='phone' type='tel' />
       <Input label='Email' path='email' type='email' />
 
-      <hr className='my-2 border-dashed border-neutral-400' />
-      <h2 className='text-center text-lg font-semibold dark:text-gray-200'>Anschrift</h2>
+      <hr className='my-2 border-dashed border-neutral-600 dark:border-neutral-400' />
+      <h2 className='text-center text-lg font-semibold text-gray-700 dark:text-gray-200'>Anschrift</h2>
 
       <Input label='Land' path='country' required />
       <Input label='Stadt' path='city' required />
@@ -98,8 +100,8 @@ function CustomerProps() {
       <Input label='Adresse' path='street' required />
       <Input label='Hausnummer' path='houseNumber' required inputClassName='min-w-1' />
 
-      <hr className='my-2 border-dashed border-neutral-400' />
-      <h2 className='text-center text-lg font-semibold dark:text-gray-200'>Optional</h2>
+      <hr className='my-2 border-dashed border-neutral-600 dark:border-neutral-400' />
+      <h2 className='text-center text-lg font-semibold text-gray-700 dark:text-gray-200'>Optional</h2>
       <Input label='Firma' path='company' />
       <Input label='ATU Nr.' path='uid_number' />
     </Container>

--- a/app/(components)/orders/DisplayOrder.tsx
+++ b/app/(components)/orders/DisplayOrder.tsx
@@ -32,7 +32,7 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
 
   const OpenButton = () => {
     return (
-      <Link target='_blank' href={href} className='mx-1 my-1 rounded-md border border-gray-400 px-2 py-2 @2xl:m-0 @2xl:px-4 dark:border-gray-500'>
+      <Link target='_blank' href={href} className='mx-1 my-1 rounded-md border border-gray-400 px-2 py-2 active:bg-neutral-300 @2xl:m-0 @2xl:px-4 dark:border-gray-500'>
         <ArrowTopRightOnSquareIcon width={16} height={16} className='block @2xl:hidden' />
         <span className='hidden @2xl:block'>Open</span>
       </Link>
@@ -48,7 +48,9 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
 
     // the margin ensures that the height of each order-element stays the same.
     return (
-      <button onClick={onClick} className='mx-1 my-1 rounded-md bg-blue-400/40 px-2 py-2 @2xl:m-0 @2xl:px-4 dark:bg-blue-600'>
+      <button
+        onClick={onClick}
+        className='mx-1 my-1 rounded-md bg-blue-400/40 px-2 py-2 hover:bg-blue-400/60 active:bg-blue-400/80 @2xl:m-0 @2xl:px-4 dark:bg-blue-600 dark:hover:ring-2 dark:hover:ring-inset dark:hover:ring-blue-500 dark:active:bg-blue-700/80'>
         <Cog6ToothIcon width={16} height={16} className='block @2xl:hidden' />
         <span className='hidden @2xl:block'>Edit</span>
       </button>

--- a/app/(components)/orders/DisplayOrder.tsx
+++ b/app/(components)/orders/DisplayOrder.tsx
@@ -32,7 +32,7 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
 
   const OpenButton = () => {
     return (
-      <Link target='_blank' href={href} className='mx-1 my-1 rounded-md border px-2 py-2 @2xl:m-0 @2xl:px-4 dark:border-gray-500'>
+      <Link target='_blank' href={href} className='mx-1 my-1 rounded-md border border-gray-400 px-2 py-2 @2xl:m-0 @2xl:px-4 dark:border-gray-500'>
         <ArrowTopRightOnSquareIcon width={16} height={16} className='block @2xl:hidden' />
         <span className='hidden @2xl:block'>Open</span>
       </Link>
@@ -48,7 +48,7 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
 
     // the margin ensures that the height of each order-element stays the same.
     return (
-      <button onClick={onClick} className='mx-1 my-1 rounded-md px-2 py-2 @2xl:m-0 @2xl:px-4 dark:bg-blue-600'>
+      <button onClick={onClick} className='mx-1 my-1 rounded-md bg-blue-400/40 px-2 py-2 @2xl:m-0 @2xl:px-4 dark:bg-blue-600'>
         <Cog6ToothIcon width={16} height={16} className='block @2xl:hidden' />
         <span className='hidden @2xl:block'>Edit</span>
       </button>
@@ -56,7 +56,7 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
   }
 
   return (
-    <div className='group flex w-full items-center gap-4 rounded-md px-3 py-2 ring-1 transition-all duration-500 @lg:gap-8 dark:ring-gray-500 dark:hover:bg-neutral-700/80'>
+    <div className='group flex w-full items-center gap-4 rounded-md px-3 py-2 text-gray-700 ring-1 ring-gray-400 transition-all duration-500 hover:bg-neutral-300/60 @lg:gap-8 dark:text-gray-200 dark:ring-gray-500 dark:hover:bg-neutral-700/80'>
       <div className={twMerge('text-sm font-semibold', visibilities.id)}>#{order.id}</div>
       <div className={twMerge(visibilities.status)}>
         <StatusIcon status={order.status} />
@@ -94,7 +94,7 @@ export default function DisplayOrder({ order, href }: { order: Order; href: stri
 export function DisplayOrderHeaders({ className }: { className?: string }) {
   return (
     <div className='@container'>
-      <div className={twMerge('flex w-full gap-4 rounded-t-md px-3 py-2 font-semibold @lg:gap-8 dark:bg-neutral-900/80', className)}>
+      <div className={twMerge('flex w-full gap-4 rounded-t-md bg-neutral-500 px-3 py-2 font-semibold text-white @lg:gap-8 dark:bg-neutral-900/80 dark:text-gray-200', className)}>
         <span className={visibilities.id}>Nr.</span>
         {/*the margins classes are used to center the status-column-label when the indicator is shown, then to align it with status idicator and status-label*/}
         <span className={twMerge(visibilities.status, '-ml-6 -mr-4 @xl:-mr-0 @xl:ml-0')}>Status</span>
@@ -113,8 +113,8 @@ function StatusIcon({ status }: { status: Order['status'] }) {
   const isFailed = status === 'failed'
 
   const getStatusColor = () => {
-    if (isCompleted) return 'text-green-400 bg-green-400/10'
-    if (isFailed) return 'text-rose-400 bg-rose-400/10'
+    if (isCompleted) return 'text-green-600 dark:text-green-400 bg-green-400/30 dark:bg-green-400/10'
+    if (isFailed) return 'text-rose-600 dark:text-rose-400 bg-rose-400/40 dark:bg-rose-400/10'
     return 'text-orange-400 bg-orange-400/20'
   }
 
@@ -123,7 +123,7 @@ function StatusIcon({ status }: { status: Order['status'] }) {
       <div className={structureClasses(getStatusColor(), 'flex-none rounded-full p-1')}>
         <div className={twMerge('h-1.5 w-1.5 rounded-full bg-current', isPending && 'animate-pulse duration-75')} />
       </div>
-      <div className='hidden text-white @xl:block'>{status}</div>
+      <div className='hidden text-gray-700 @xl:block dark:text-gray-200'>{status}</div>
     </div>
   )
 }


### PR DESCRIPTION
The following changes were made in this Pull request:
- added light-mode styles in the `DisplayOrder` component
- added hover and active styles for light and dark mode in the `DisplayOrder` component
- added light-mode styles in the `DisplayOrder` component
- added light-mode styles to the `CustomerRegistrationMenu`
- updated light-mode styles of the `Slide-Over Header`