### PR TITLE
Feat: Implementation of Feed Components

### DIFF
--- a/app/(components)/Shared/Feeds/Feed.tsx
+++ b/app/(components)/Shared/Feeds/Feed.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+import FeedTitle from '@/components/Shared/Feeds/Partial/FeedTitle'
+import FeedDate from '@/components/Shared/Feeds/Partial/FeedDate'
+
+export interface BasicFeedProps {
+  title: string
+  description: string
+  icon?: ReactNode
+  date: string
+  link?: string
+}
+
+/**
+ * Displays a basic feed that has a title that is highlighted and a description that comes right after. The date is displayed at the end.
+ * @param title The title of the feed that is highlighted
+ * @param description The description of the feed
+ * @param icon The icon that is displayed in front of the title
+ * @param date The time that has passed since that feed was created
+ * @param link The link that is opened when the title is clicked
+ * @constructor
+ */
+export default function Feed({ title, description, icon, date, link }: BasicFeedProps) {
+  return (
+    <>
+      <li key={title + description + date} className='group relative flex gap-x-3'>
+        <div className={twMerge('-bottom-6', 'absolute left-0 top-0 flex w-6 justify-center group-first:top-2 group-last:h-4')}>
+          <div className='w-px bg-gray-300 dark:bg-gray-400' />
+        </div>
+
+        <FeedTitle title={title} description={description} icon={icon} link={link} />
+        <FeedDate dateString={date} className='pr-3' />
+      </li>
+    </>
+  )
+}

--- a/app/(components)/Shared/Feeds/FeedComment.tsx
+++ b/app/(components)/Shared/Feeds/FeedComment.tsx
@@ -1,0 +1,45 @@
+import { twMerge } from 'tailwind-merge'
+import Image from 'next/image'
+import FeedDate from '@/components/Shared/Feeds/Partial/FeedDate'
+
+interface FeedCommentProps {
+  avatar?: string
+  name: string
+  comment?: string
+  date: string
+}
+/**
+ * Displays a comment as a Feed.
+ * @param avatar The image of the person who commented
+ * @param name The name of the person who commented
+ * @param comment The comment of the person
+ * @param date The date of the comment
+ *
+ */
+export default function FeedComment({ avatar, name, date, comment }: FeedCommentProps) {
+  const defaultIMG = 'https://images.unsplash.com/photo-1552058544-f2b08422138a?w=900&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8N3x8cGVyc29ufGVufDB8fDB8fHww'
+
+  return (
+    <>
+      <li key={name + date + comment} className='group relative flex gap-x-3'>
+        <div className={twMerge('-bottom-6', 'absolute left-0 top-0 flex w-6 justify-center group-first:top-3 group-last:h-4')}>
+          <div className='w-px bg-gray-300 dark:bg-gray-400' />
+        </div>
+
+        <Image width={24} height={24} src={avatar ?? defaultIMG} alt='' className='relative mt-3 h-6 w-6 flex-none rounded-full bg-gray-50' />
+
+        <div className='flex-auto rounded-md p-3 ring-1 ring-inset ring-gray-200'>
+          <div className='flex justify-between gap-x-4'>
+            <div className='py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-400'>
+              <span className='font-medium text-gray-900 dark:text-gray-100'>{name}</span> commented
+            </div>
+
+            <FeedDate dateString={date} />
+          </div>
+
+          <p className='text-sm leading-6 text-gray-500 dark:text-gray-400'>{comment}</p>
+        </div>
+      </li>
+    </>
+  )
+}

--- a/app/(components)/Shared/Feeds/FeedContainer.tsx
+++ b/app/(components)/Shared/Feeds/FeedContainer.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+export default function FeedContainer({ children, className }: { children?: ReactNode; className?: string }) {
+  return (
+    <>
+      <ul role='list' className={twMerge('space-y-6', className)}>
+        {children}
+      </ul>
+    </>
+  )
+}

--- a/app/(components)/Shared/Feeds/MinorFeed.tsx
+++ b/app/(components)/Shared/Feeds/MinorFeed.tsx
@@ -1,0 +1,40 @@
+import { twMerge } from 'tailwind-merge'
+import FeedTitle from '@/components/Shared/Feeds/Partial/FeedTitle'
+import FeedDate from '@/components/Shared/Feeds/Partial/FeedDate'
+import { BasicFeedProps } from '@/components/Shared/Feeds/Feed'
+
+/**
+ * Displays a basic feed that has a title that is highlighted and a description that comes right after. The date is displayed at the end.
+ * @param title The title of the feed that is highlighted
+ * @param description The description of the feed
+ * @param icon The icon that is displayed in front of the title
+ * @param date The time that has passed since that feed was created
+ * @param link The link that is opened when the title is clicked
+ * @param single Whether the feed is the only child of the parent-feed
+ * @param last Whether the feed is the last child of the parent-feed-container
+ * @constructor
+ */
+export default function MinorFeed({ title, description, icon, date, link, single, last }: BasicFeedProps & { single?: boolean; last?: boolean }) {
+  return (
+    <>
+      <li key={title + description + date + Math.random()} className='group relative ml-12 flex gap-x-3'>
+        <div className={twMerge('-bottom-6', 'absolute left-0 top-0 flex w-6 justify-center group-first:top-2 group-last:h-4')}>
+          {/* Vertical Connect at the top*/}
+          <div className={twMerge('absolute -top-3 right-[3.72rem] hidden h-4 w-px bg-gray-300 group-first:block dark:bg-gray-400')} />
+          {/* Horizontal Connecter at the top*/}
+          <div className='absolute right-4 top-[0.21rem] hidden h-px w-[2.78rem] bg-gray-300 group-first:block dark:bg-gray-400' />
+
+          {!single && <div className='w-px bg-gray-300 dark:bg-gray-400' />}
+
+          {/* Horizontal Connecter at the bottom*/}
+          <div className={twMerge('absolute bottom-[0.22rem] right-4 hidden h-px w-[2.78rem] bg-gray-300 group-last:block dark:bg-gray-400', (single || last) && 'hidden group-last:hidden')} />
+          {/* Vertical Connect at the bottom*/}
+          <div className={twMerge('absolute -bottom-8 right-[3.72rem] hidden h-9 w-px bg-gray-300 group-last:block dark:bg-gray-400', single && 'h-11', last && 'hidden group-last:hidden')} />
+        </div>
+
+        <FeedTitle title={title} description={description} icon={icon} link={link} />
+        <FeedDate dateString={date} className='pr-3' />
+      </li>
+    </>
+  )
+}

--- a/app/(components)/Shared/Feeds/Partial/FeedDate.tsx
+++ b/app/(components)/Shared/Feeds/Partial/FeedDate.tsx
@@ -1,0 +1,11 @@
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Displays the date of a Feed.
+ * @param date The time that has passed since that feed was created
+ * @param className Additional classes that are applied to the date
+ * @internal Partial component that is used to build a Feed
+ */
+export default function FeedDate({ dateString, className }: { dateString: string; className?: string }) {
+  return <span className={twMerge('flex-none py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-400', className)}>{dateString}</span>
+}

--- a/app/(components)/Shared/Feeds/Partial/FeedTitle.tsx
+++ b/app/(components)/Shared/Feeds/Partial/FeedTitle.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react'
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Displays the title and description of a Feed.
+ * @param title The title of the feed that is highlighted
+ * @param description The description of the feed
+ * @param icon The icon that is displayed in front of the title
+ * @param link The link that is opened when the title is clicked
+ * @internal Partial component that is used to build a Feed
+ */
+export default function FeedTitle({ title, description, icon, link }: { title: string; description: string; icon?: ReactNode; link?: string }) {
+  const Container = ({ children, className }: { children: ReactNode; className?: string }) =>
+    link ? (
+      <Link href={link} className={className}>
+        {children}
+      </Link>
+    ) : (
+      <span className={className}>{children}</span>
+    )
+
+  return (
+    <>
+      <div className='relative flex h-6 w-6 flex-none items-center justify-center rounded-full bg-gray-300 dark:bg-white/15'>
+        {icon ? icon : <div className='h-1.5 w-1.5 rounded-full bg-white ring-1 ring-gray-300 dark:bg-gray-300' />}
+      </div>
+
+      <p className='line-clamp-1 flex-auto py-0.5 text-xs leading-5 text-gray-500 dark:text-gray-400'>
+        <Container className={twMerge('font-medium text-gray-900 dark:text-gray-100', link && 'hover:underline')}>{title}</Container> {description}
+      </p>
+    </>
+  )
+}

--- a/app/(components)/Shared/Feeds/WriteFeedComment.tsx
+++ b/app/(components)/Shared/Feeds/WriteFeedComment.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { ButtonHTMLAttributes } from 'react'
+import { FireIcon } from '@heroicons/react/20/solid'
+import Image from 'next/image'
+
+interface CommandOption {
+  name: string
+  value: string
+  icon: typeof FireIcon
+  iconColor: string | 'text-gray-400'
+  bgColor: string | 'bg-red-400'
+}
+
+interface CommendFeedProps {
+  action?: ButtonHTMLAttributes<any>['formAction']
+  options?: CommandOption[]
+}
+
+export default function WriteCommentFeed({ action }: CommendFeedProps) {
+  return (
+    <div className='mt-6 flex gap-x-3'>
+      <Image
+        width={24}
+        height={24}
+        src='https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80'
+        alt=''
+        className='h-6 w-6 flex-none rounded-full bg-gray-50'
+      />
+
+      <form className='relative flex-auto'>
+        <div className='flex overflow-hidden rounded-lg pb-12 shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600 dark:focus-within:ring-gray-200/90'>
+          <label htmlFor='comment' className='sr-only'>
+            Add your comment
+          </label>
+
+          <textarea
+            rows={2}
+            name='comment'
+            id='comment'
+            className='mr-2 mt-2 block flex-1 resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 dark:text-gray-400 sm:text-sm sm:leading-6'
+            placeholder='Add your comment...'
+            defaultValue={''}
+          />
+        </div>
+
+        <div className='absolute inset-x-0 bottom-0 flex justify-end py-2 pl-3 pr-2'>
+          <button
+            formAction={action}
+            className='rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-300/90 dark:hover:bg-gray-300'>
+            Comment
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@heroicons/react": "^2.0.18",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.7",
+    "date-fns": "^3.3.1",
     "hellocash-api": "1.0.4",
     "mongodb": "^6.3.0",
     "next": "14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@ data-uri-to-buffer@^4.0.0:
   resolved "http://10.0.100.10:4873/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
+date-fns@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.3.1.tgz#7581daca0892d139736697717a168afbb908cfed"
+  integrity sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==
+
 debug@=3.1.0:
   version "3.1.0"
   resolved "http://10.0.100.10:4873/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"


### PR DESCRIPTION
The following changes were made in this Pull request:
- installed `date-fns`package that provides useful utilities for working with date-objects
- created `FeedContainer` component that wraps around the `Feed` components and sets the spacing between Feeds
- created `FeedTitle` component
   This component simply renders a highlighted title and description. 
   It also allows the user to provide an icon, that is then displayed in front of the title.
   It also takes in an optional argument called link, which wraps the title in a `Link`-element.
- created `FeedDate` component
  This component simply renders a span-element that renders a given date-string

- created `Feed` component
  This component uses the `FeedTitle` and `FeedDate` components to create new `Feed`

- created `MinorFeed` component
   This component extends the basic `Feed`. It has a margin-left and can be used as a sub-`Feed` of a given `Feed`.  
   In order to use the `MinorFeed`s another `FeedContainer` is used after the parent-Feed, that wraps all the `MinorFeed` components. In doing so the first `MinorFeed` connects to the parent `Feed` and the last `MinorFeed` connects to the next parent `Feed`.

- created `FeedComment` component
  This component displays a comment as a `Feed`. That means, that it not only renders a title, description and date, but also a comment below. Note, that each `FeedComment` is highlighted with a border, to stand out from the other feeds.

- created `WriteFeedComment` component
  This component provides a textarea, where the user can write a new comment. It matches the styles of the previous Feed-components and may be used at the of a `FeedContainer`.

