### PR TITLE
Feat: Customer Buy History using Feeds 

### DIFF
--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import getHellocashAPI from '@/lib/Shared/HelloCash'
+
+export async function GET(req: Request) {
+  const params = new URL(req.url).searchParams
+  const limit = parseInt(params?.get('limit')?.toString() ?? '25')
+
+  const { getInvoices } = getHellocashAPI()
+  const invoices = await getInvoices(parseInt(limit?.toString() ?? '25'))
+
+  return NextResponse.json(invoices)
+}

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -6,7 +6,7 @@ export async function GET(req: Request) {
   const limit = parseInt(params?.get('limit')?.toString() ?? '25')
 
   const { getInvoices } = getHellocashAPI()
-  const invoices = await getInvoices(parseInt(limit?.toString() ?? '25'))
+  const invoices = await getInvoices(limit)
 
   return NextResponse.json(invoices)
 }

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server'
 import getWoocommerceApi from '@/lib/Shared/Woocommerce'
 
-export async function GET(req: Request, context: { params: any }) {
-  const limit = context.params?.limit
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  const params = new URL(req.url).searchParams
+  const limit = parseInt(params?.get('limit')?.toString() ?? '25')
+
   const { getOrders } = await getWoocommerceApi()
-  const orders = await getOrders(parseInt(limit?.toString() ?? '25'))
+  const orders = await getOrders(limit)
 
   return NextResponse.json(orders)
 }

--- a/app/customer-history/[cid]/CustomerBuyHistory.tsx
+++ b/app/customer-history/[cid]/CustomerBuyHistory.tsx
@@ -44,7 +44,7 @@ export default async function CustomerBuyHistory({ customer }: { customer: Custo
                       title={`Quantity: ${item.quantity}x`}
                       single={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand')).length === 1}
                       last={index === invoices.length - 1}
-                      date={formatDate(invoice.timestamp, 'dd.mm.yyyy')}
+                      date={formatDate(invoice.timestamp, 'dd. MMM yyyy')}
                     />
                   )}
                 />

--- a/app/customer-history/[cid]/CustomerBuyHistory.tsx
+++ b/app/customer-history/[cid]/CustomerBuyHistory.tsx
@@ -1,5 +1,4 @@
 import { Invoice } from 'hellocash-api/typings/Invoice'
-import { Customer } from 'hellocash-api/typings/Customer'
 import Each from '@/lib/Shared/Each'
 import { formatDate, formatDistance } from 'date-fns'
 import { CheckCircleIcon } from '@heroicons/react/24/solid'
@@ -8,51 +7,46 @@ import Feed from '@/components/Shared/Feeds/Feed'
 import MinorFeed from '@/components/Shared/Feeds/MinorFeed'
 
 /**
- * Displays a list of invoices of a given customer and the items that were bought in each invoice.
- * @param customer The customer whoos history shall be displayed
+ * Displays a list of invoices in the form of feeds. Each feed contains the invoice number, the customer who bought the items and the items of the invoice themselves.
+ * @param invoices The invoices that are to be displayed. The invoices should be filtered to only contain by the customer in question.
  * @constructor
  */
-export default async function CustomerBuyHistory({ customer }: { customer: Customer; invoices?: Invoice[] }) {
-  let invoices = await fetch(`${process.env.BACKEND}/invoices?limit=-1`, { next: { revalidate: 3600 * 24, tags: ['invoices'] } })
-    .then((res) => res.json())
-    .then((json) => json as Invoice[])
-  invoices = invoices.filter((i) => i.customer?.id == customer.id)
+export default async function CustomerBuyHistory({ invoices }: { invoices: Invoice[] }) {
+  invoices = invoices.filter((i) => !!i.customer)
 
   return (
-    <>
-      <FeedContainer>
-        <Each
-          items={invoices}
-          render={(invoice, index) => (
-            <>
-              <Feed
-                key={invoice.id}
-                link={`/invoice/${invoice.id}`}
-                icon={<CheckCircleIcon className='h-6 w-6 rounded-full text-indigo-600 dark:bg-neutral-700 dark:text-green-500 dark:ring-2 dark:ring-green-500/30' />}
-                title={'#' + invoice.id.toString()}
-                description={`${customer.firstName} ${customer.lastName} bought the following item${invoice.items.length > 1 && 's'}:`}
-                date={`${formatDistance(invoice.timestamp, new Date())} ago`}
-              />
+    <FeedContainer>
+      <Each
+        items={invoices}
+        render={(invoice, index) => (
+          <>
+            <Feed
+              key={invoice.id}
+              link={`/invoice/${invoice.id}`}
+              icon={<CheckCircleIcon className='h-6 w-6 rounded-full text-indigo-600 dark:bg-neutral-700 dark:text-green-500 dark:ring-2 dark:ring-green-500/30' />}
+              title={'#' + invoice.id.toString()}
+              description={`${invoice!.customer!.firstName} ${invoice!.customer!.lastName} bought the following item${invoice.items.length > 1 ? 's' : ''}:`}
+              date={`${formatDistance(invoice.timestamp, new Date())} ago`}
+            />
 
-              <FeedContainer>
-                <Each
-                  items={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand'))}
-                  render={(item, item_index) => (
-                    <MinorFeed
-                      key={invoice.id + '-' + item.id + '-' + item_index}
-                      description={item.name}
-                      title={`Quantity: ${item.quantity}x`}
-                      single={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand')).length === 1}
-                      last={index === invoices.length - 1}
-                      date={formatDate(invoice.timestamp, 'dd. MMM yyyy')}
-                    />
-                  )}
-                />
-              </FeedContainer>
-            </>
-          )}
-        />
-      </FeedContainer>
-    </>
+            <FeedContainer>
+              <Each
+                items={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand'))}
+                render={(item, item_index) => (
+                  <MinorFeed
+                    key={invoice.id + '-' + item.id + '-' + item_index}
+                    description={item.name}
+                    title={`Quantity: ${item.quantity}x`}
+                    single={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand')).length === 1}
+                    last={index === invoices.length - 1}
+                    date={formatDate(invoice.timestamp, 'dd. MMM yyyy')}
+                  />
+                )}
+              />
+            </FeedContainer>
+          </>
+        )}
+      />
+    </FeedContainer>
   )
 }

--- a/app/customer-history/[cid]/CustomerBuyHistory.tsx
+++ b/app/customer-history/[cid]/CustomerBuyHistory.tsx
@@ -1,0 +1,58 @@
+import { Invoice } from 'hellocash-api/typings/Invoice'
+import { Customer } from 'hellocash-api/typings/Customer'
+import Each from '@/lib/Shared/Each'
+import { formatDate, formatDistance } from 'date-fns'
+import { CheckCircleIcon } from '@heroicons/react/24/solid'
+import FeedContainer from '@/components/Shared/Feeds/FeedContainer'
+import Feed from '@/components/Shared/Feeds/Feed'
+import MinorFeed from '@/components/Shared/Feeds/MinorFeed'
+
+/**
+ * Displays a list of invoices of a given customer and the items that were bought in each invoice.
+ * @param customer The customer whoos history shall be displayed
+ * @constructor
+ */
+export default async function CustomerBuyHistory({ customer }: { customer: Customer; invoices?: Invoice[] }) {
+  let invoices = await fetch(`${process.env.BACKEND}/invoices?limit=-1`, { next: { revalidate: 3600 * 24, tags: ['invoices'] } })
+    .then((res) => res.json())
+    .then((json) => json as Invoice[])
+  invoices = invoices.filter((i) => i.customer?.id == customer.id)
+
+  return (
+    <>
+      <FeedContainer>
+        <Each
+          items={invoices}
+          render={(invoice, index) => (
+            <>
+              <Feed
+                key={invoice.id}
+                link={`/invoice/${invoice.id}`}
+                icon={<CheckCircleIcon className='h-6 w-6 rounded-full text-indigo-600 dark:bg-neutral-700 dark:text-green-500 dark:ring-2 dark:ring-green-500/30' />}
+                title={'#' + invoice.id.toString()}
+                description={`${customer.firstName} ${customer.lastName} bought the following item${invoice.items.length > 1 && 's'}:`}
+                date={`${formatDistance(invoice.timestamp, new Date())} ago`}
+              />
+
+              <FeedContainer>
+                <Each
+                  items={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand'))}
+                  render={(item, item_index) => (
+                    <MinorFeed
+                      key={invoice.id + '-' + item.id + '-' + item_index}
+                      description={item.name}
+                      title={`Quantity: ${item.quantity}x`}
+                      single={invoice.items.filter((i) => !i.name.toLowerCase().includes('versand')).length === 1}
+                      last={index === invoices.length - 1}
+                      date={formatDate(invoice.timestamp, 'dd.mm.yyyy')}
+                    />
+                  )}
+                />
+              </FeedContainer>
+            </>
+          )}
+        />
+      </FeedContainer>
+    </>
+  )
+}

--- a/app/customer-history/[cid]/page.tsx
+++ b/app/customer-history/[cid]/page.tsx
@@ -1,0 +1,13 @@
+import getHellocashAPI from '@/lib/Shared/HelloCash'
+import CustomerBuyHistory from '@/app/customer-history/[cid]/CustomerBuyHistory'
+import { notFound } from 'next/navigation'
+
+export default async function CustomerHistoryPage({ params }: { params: { cid?: string } }) {
+  if (!params.cid) return notFound()
+  const { findExactCustomer } = getHellocashAPI()
+  const customer = await findExactCustomer({ id: params.cid }).then((customers) => customers.at(0))
+
+  if (!customer) return <div>Customer not found</div>
+
+  return <CustomerBuyHistory customer={customer} />
+}

--- a/hooks/Shared/Fetch/useBackend.ts
+++ b/hooks/Shared/Fetch/useBackend.ts
@@ -1,0 +1,14 @@
+/**
+ * This hook makes a fetch request to the backend and the given subroute with the given options
+ * @param route The subroute to the backend. (..../api/<route>)
+ * @param options Further options for the fetch request
+ */
+export default async function useBackend<T = unknown>(route: string | 'orders', options: RequestInit) {
+  if (route.startsWith('/api')) route = route.slice(4)
+  if (route.startsWith('api')) route = route.slice(3)
+  if (!route.startsWith('/')) route = '/' + route
+
+  return fetch(`${process.env.BACKEND}${route}`, options)
+    .then((res) => res.json())
+    .then((json) => json as T)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,11 @@ const nextConfig = {
         protocol: 'https',
         pathname: '/u/**',
       },
+      {
+        hostname: 'images.unsplash.com',
+        protocol: 'https',
+        pathname: '/photo-**',
+      },
     ],
   },
 }


### PR DESCRIPTION
The following changes were made in this Pull request:
- created `api/invoices?limit=<>` endpoint which returns a requested amount of invoices
- updated `api/orders` endpoint to properly handle the searchParams
- created `CustomerBuyHistory` component
  This component requires an array of invoices that are then display using feeds. By doing it is possible to use this component in many different ways. 
   - For instance, one can show the history for a given user by filtering the invoices by that specific user. 
   - Another example would be to only show the history of invoices that have certain items and to only show the history for those items, by filtering the invoices, which have the requested items. Then simply filter the invoice-items to only include the ones in question.
- created `/customer-history/[cid]` page
  This page renders the buy-history for a given customer. In case the requested cid is invalid or no customer is found, then a response will be shown on the page. 