### PR TITLE
Refactor: Imrproved the Code Quality by Reworking the `useHeroIcon` (previously: useIcon) hook 

### DIFF
--- a/app/(components)/root/NavigationBar/SideBar.tsx
+++ b/app/(components)/root/NavigationBar/SideBar.tsx
@@ -16,12 +16,12 @@ export default async function SideBar() {
       { name: 'Home', icon: 'HomeIcon', href: '/' },
       {
         name: 'Orders',
-        icon: 'FolderIcon',
+        icon: 'ShoppingBagIcon',
         href: '/orders',
       },
       {
         name: 'Articles',
-        icon: 'FolderIcon',
+        icon: 'TableCellsIcon',
         href: '/articles',
       },
     ],

--- a/app/(components)/root/NavigationBar/SideElement.tsx
+++ b/app/(components)/root/NavigationBar/SideElement.tsx
@@ -4,12 +4,12 @@ import { twMerge } from 'tailwind-merge'
 import { Disclosure, Transition } from '@headlessui/react'
 import structureClasses from '@/lib/Shared/structureClasses'
 import Link from 'next/link'
-import useIcon, { useIconProps } from '@/lib/Shared/useIcon'
+import useHeroIcon, { HeroIconName } from '@/lib/Shared/useIcon'
 
 export interface SideElementProps {
   name: string
   href?: string
-  icon?: useIconProps['iconName']
+  icon?: HeroIconName
   isOpen?: boolean
   subitems?: SideElementProps[] | any[]
   badge?: number
@@ -67,7 +67,7 @@ export default function SideElement(element: SideElementProps) {
  * @constructor
  */
 function BasicElement({ name, icon: iconName, subitems, isOpen, badge }: SideElementProps) {
-  const Icon = useIcon(iconName)
+  const Icon = useHeroIcon(iconName)
 
   const imgClasses = structureClasses(
     isOpen ? 'text-indigo-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400 dark:group-hover:stroke-blue-400 group-hover:text-indigo-600',
@@ -76,8 +76,12 @@ function BasicElement({ name, icon: iconName, subitems, isOpen, badge }: SideEle
 
   return (
     <>
-      <Icon key={name + isOpen} className={imgClasses} />
-      <span className={twMerge('text-sm leading-6 text-gray-600 group-hover:text-indigo-600 dark:text-gray-300 dark:group-hover:text-blue-400', isOpen ? 'text-indigo-600 dark:text-blue-400' : '')}>
+      {Icon && <Icon key={name + isOpen} className={imgClasses} />}
+      <span
+        className={twMerge(
+          'text-sm leading-6 text-gray-600 group-hover:text-indigo-600 dark:text-gray-300 dark:group-hover:text-blue-400',
+          isOpen ? 'text-indigo-600 dark:text-blue-400' : '',
+        )}>
         {name}
       </span>
       <div className='flex flex-1 items-center justify-end gap-2'>

--- a/lib/Shared/useIcon.tsx
+++ b/lib/Shared/useIcon.tsx
@@ -1,46 +1,15 @@
-import { ComponentType } from 'react'
-import IconProps from '@/typings/Icon'
-import { AdjustmentsVerticalIcon, BuildingStorefrontIcon, CursorArrowRaysIcon, FolderIcon, HomeIcon, LockOpenIcon, ShoppingBagIcon } from "@heroicons/react/24/outline"
-// import FolderIcon from '@/public/next.svg'
-// import BuildingStoreFrontIcon from '@/public/next.svg'
-// import CursorArrowRaysIcon from '@/public/next.svg'
-// import ShoppingBagIcon from '@/public/next.svg'
-// import HomeIcon from '@/public/next.svg'
-// import AdjustmentsVerticalIcon from '@/public/next.svg'
-// import LockOpenIcon from '@/public/next.svg'
+import * as icons from '@heroicons/react/24/outline'
 
-export interface useIconProps {
-  iconName: 'FolderIcon' | 'AdjustmentsVerticalIcon' | 'BuildingStoreFrontIcon' | 'CursorArrowRaysIcon' | 'HomeIcon' | 'ShoppingBagIcon' | 'LockOpenIcon' | undefined
-}
+export type HeroIconName = keyof typeof icons & {}
 
-export default function useIcon(iconName: useIconProps['iconName']) {
-  let Icon = (): ComponentType<IconProps> => {
-    switch (iconName) {
-      case 'FolderIcon':
-        return FolderIcon
+/**
+ * This hook returns the requested icon from the heroicons package based on its name (key)
+ * @param name - The name of the icon
+ * @returns The requested icon or null in case the name is used optionally
+ */
+export default function useHeroIcon(name?: HeroIconName) {
+  if (!name) return null
 
-      case 'AdjustmentsVerticalIcon':
-        return AdjustmentsVerticalIcon
-
-      case 'HomeIcon':
-        return HomeIcon
-
-      case 'BuildingStoreFrontIcon':
-        return BuildingStorefrontIcon
-
-      case 'CursorArrowRaysIcon':
-        return CursorArrowRaysIcon
-
-      case 'ShoppingBagIcon':
-        return ShoppingBagIcon
-
-      case 'LockOpenIcon':
-        return LockOpenIcon
-
-      default:
-        return () => null
-    }
-  }
-
-  return Icon()
+  //? Returns the requested icon based on the name (key)
+  return Object.values(icons).at(Object.keys(icons).indexOf(name)) as typeof icons.FireIcon
 }


### PR DESCRIPTION
The following changes where made in this Pull request:
- reworked the `useHeroIcon` hook previously known as `useIcon`
   The new hook now accepts a name property that can be set to any icon-name of the hero-icons package. In case the name property is undefined, e.g. when the icon name is used conditionally, then null will be returned. 
- updated `SideElement` component
   Updated the iconName type from `useIconProps` to `HeroIconName`. Additionally the old use of the  hook was replaced with the new one (`useHeroIcon`)
- changed the SideBar icons