### PR TITLE
Feat: Implemenation of a Smooth Initial Table Animation 

### DIFF
--- a/app/(components)/Shared/Table/Table.tsx
+++ b/app/(components)/Shared/Table/Table.tsx
@@ -7,6 +7,7 @@ import { once } from 'lodash'
 import TableColumnLabels from '@/components/Shared/Table/TableColumnLabels'
 import TableItems from '@/components/Shared/Table/TableItems'
 import TableSearchBar from '@/components/Shared/Table/TableSearchBar'
+import { motion } from 'framer-motion'
 
 const createGenericTableContext = once(<T,>() => createContext<T>({} as T))
 
@@ -54,9 +55,9 @@ export default function Table<T>({ items: initialItems, visibilities, searchFilt
               <TableColumnLabels />
             </tr>
           </thead>
-          <tbody className='space-y-24 divide-y divide-gray-400 px-2 dark:divide-neutral-500'>
+          <motion.tbody initial='hidden' animate='visible' className='space-y-24 divide-y divide-gray-400 px-2 dark:divide-neutral-500'>
             <TableItems />
-          </tbody>
+          </motion.tbody>
         </table>
       </div>
     </Context.Provider>

--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -5,6 +5,19 @@ import Each from '@/lib/Shared/Each'
 import getKeys from '@/lib/Shared/Keys'
 import React from 'react'
 import useTableSelection from '@/hooks/Table/useTableSelection'
+import { motion } from 'framer-motion'
+
+const animationVariants = {
+  hidden: { opacity: 0, y: -24, borderStyle: 'dotted' },
+  visible: (i: number) => ({
+    y: 0,
+    opacity: 1,
+    borderStyle: 'solid',
+    transition: {
+      delay: i * 0.02, // staggered effect with an incremental delay
+    },
+  }),
+}
 
 export default function TableItems<T>() {
   const { items } = useTableContext<T>()
@@ -13,13 +26,15 @@ export default function TableItems<T>() {
   return Each({
     items,
     render: (item, index: number) => (
-      <tr
+      <motion.tr
+        custom={index}
+        variants={animationVariants}
         key={item.id.toString() + index.toString()}
         onClick={toggleSelection(item)}
         className={twMerge('h-12 px-4 transition-colors duration-200 dark:hover:bg-neutral-700', isSelected(item) && 'dark:bg-neutral-700/60 dark:hover:bg-neutral-700')}>
         <SelectCheckBox item={item} />
         <TableItem item={item} />
-      </tr>
+      </motion.tr>
     ),
   })
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@types/lodash": "^4.14.202",
     "date-fns": "^3.3.1",
+    "framer-motion": "^11.0.20",
     "hellocash-api": "1.0.4",
     "lodash": "^4.17.21",
     "mongodb": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,13 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
+framer-motion@^11.0.20:
+  version "11.0.20"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.0.20.tgz#6bb72bd0b8020fc417a40453b9247d596acbea78"
+  integrity sha512-YSDmWznt3hpdERosbE0UAPYWoYhTnmQ0J1qWPsgpCia9NgY8Xsz5IpOiUEGGj/nzCAW29fSrWugeLRkdp5de7g==
+  dependencies:
+    tslib "^2.4.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
The following changes are made by this Pull request:
- installed the `framer-motion` package
- specified `animationVariants` which specify what is to be animated
- replaced the table-row (`tr`) tag with the `motion.tr` tag and set the variants property to `animationVariants`
- replaced the table-body (`tbody`) with the `motion.tbody` tag and set the initial property to 'hidden' and the animate property to 'visible' 