### PR TITLE
Refactor: Changed Default Styles of Table-Items + Fixed Table-SearchBar Filtering process (Typo)

### DIFF
--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -31,7 +31,10 @@ export default function TableItems<T>() {
         variants={animationVariants}
         key={item.id.toString() + index.toString()}
         onClick={toggleSelection(item)}
-        className={twMerge('h-12 px-4 transition-colors duration-200 dark:hover:bg-neutral-700', isSelected(item) && 'dark:bg-neutral-700/60 dark:hover:bg-neutral-700')}>
+        className={twMerge(
+          'h-12 px-4 transition-colors duration-200 dark:text-gray-300 dark:hover:bg-neutral-700',
+          isSelected(item) && 'dark:bg-neutral-700/60 dark:text-gray-100 dark:hover:bg-neutral-700',
+        )}>
         <SelectCheckBox item={item} />
         <TableItem item={item} />
       </motion.tr>

--- a/app/(components)/Shared/Table/TableSearchBar.tsx
+++ b/app/(components)/Shared/Table/TableSearchBar.tsx
@@ -5,7 +5,7 @@ import { useTableContext } from '@/components/Shared/Table/Table'
 import TableProps, { TableElement } from '@/typings/Shared/Table/Types'
 
 export default function TableSearchBar<T>() {
-  const { items: initialItems, searchFilter, setItems } = useTableContext<T>()
+  const { initialItems, searchFilter, setItems } = useTableContext<T>()
 
   const [searchValue, setSearchValue] = useState<string | undefined>(undefined)
   const [debouncedValue] = useDebounce(searchValue, 500)
@@ -41,6 +41,8 @@ function applySearchFilters<T>(item: TableElement<T>, searchValue: string, filte
   const filteredProperties = Object.keys(item).filter((k) => filters.includes(k as keyof T))
   return filteredProperties.some((k) => {
     const key = k as keyof TableElement<T>
+    if (!item[key]) return false
+
     return item[key].toString().toLowerCase().includes(searchValue.toLowerCase())
   })
 }


### PR DESCRIPTION
The following changes are made in this Pull request:
- added tw-classes to the table-items, so that not selected items have a text-color of text-gray-300 and selected items text-gray-100 in the dark color-mode
- replaced the retrieved items from the TableContext, destructuring `initialItems` instead of `items` 
- added a condition to check whether the filtered item-property is valid, thus not null. 