### PR TITLE
Feat: Implementation of Table Selection and Item Buttons

### DIFF
--- a/app/(components)/Shared/Table/Table.tsx
+++ b/app/(components)/Shared/Table/Table.tsx
@@ -6,8 +6,8 @@ import TableProps, { TableContext, TableElement } from '@/typings/Shared/Table/T
 import { once } from 'lodash'
 import TableColumnLabels from '@/components/Shared/Table/TableColumnLabels'
 import TableItems from '@/components/Shared/Table/TableItems'
-import TableSearchBar from '@/components/Shared/Table/TableSearchBar'
 import { motion } from 'framer-motion'
+import TableSearchBar from '@/components/Shared/Table/TableSearchBar'
 
 const createGenericTableContext = once(<T,>() => createContext<T>({} as T))
 
@@ -22,9 +22,10 @@ export const useTableContext = <T,>() => useContext<TableContext<T>>(createGener
  * @param labels The labels for each (or partial) item-property of an item, that are displayed as the table headers.
  * @param noDefaultLabels Whether the Table component should provide default labels, based on the property-keys of the items, for the labels that were not provided.
  * @param itemButtons Takes in a functional component that receives the current row's item and returns buttons that are displayed in the last column.
+ * @param selectionButtons Buttons that are displayed above the table, that can be used to perform actions on the selected items.
  * @returns
  */
-export default function Table<T>({ items: initialItems, labels, noDefaultLabels, ...props }: TableProps<T>) {
+export default function Table<T>({ items: initialItems, labels, noDefaultLabels, selectionButtons, ...props }: TableProps<T>) {
   const Context = createGenericTableContext<TableContext<T>>()
   type Item = TableElement<T>
   const defaultLabels = Object.keys(initialItems[0]).reduce((acc, key) => ({ ...acc, [key]: key }), {} as { [key in keyof Item]: string })
@@ -43,8 +44,11 @@ export default function Table<T>({ items: initialItems, labels, noDefaultLabels,
         setSelection: setSelected,
         ...props,
       }}>
-      <div className='wrapper relative mt-12 @container 2xs:mt-0'>
-        <TableSearchBar />
+      <div className='wrapper relative @container 2xs:mt-0'>
+        <div className='flex items-end justify-end px-1 py-2'>
+          <div className={twMerge('flex flex-1 flex-wrap gap-2', selected.length === 0 && 'opacity-25')}>{selectionButtons}</div>
+          <TableSearchBar className='flex-1' />
+        </div>
         <table className='w-full rounded-md'>
           <thead className='bg-gray-700 py-2 text-left dark:bg-neutral-900'>
             <tr className='space-x-24 text-gray-100 dark:text-gray-200'>

--- a/app/(components)/Shared/Table/Table.tsx
+++ b/app/(components)/Shared/Table/Table.tsx
@@ -21,9 +21,10 @@ export const useTableContext = <T,>() => useContext<TableContext<T>>(createGener
  * @param searchFilter Takes in the properties of an item as an array, that are then used by the search-input to filter the displayed items.
  * @param labels The labels for each (or partial) item-property of an item, that are displayed as the table headers.
  * @param noDefaultLabels Whether the Table component should provide default labels, based on the property-keys of the items, for the labels that were not provided.
+ * @param itemButtons Takes in a functional component that receives the current row's item and returns buttons that are displayed in the last column.
  * @returns
  */
-export default function Table<T>({ items: initialItems, visibilities, searchFilter, labels, noDefaultLabels }: TableProps<T>) {
+export default function Table<T>({ items: initialItems, labels, noDefaultLabels, ...props }: TableProps<T>) {
   const Context = createGenericTableContext<TableContext<T>>()
   type Item = TableElement<T>
   const defaultLabels = Object.keys(initialItems[0]).reduce((acc, key) => ({ ...acc, [key]: key }), {} as { [key in keyof Item]: string })
@@ -38,10 +39,9 @@ export default function Table<T>({ items: initialItems, visibilities, searchFilt
         initialItems,
         items,
         setItems,
-        visibilities,
         selection: selected,
         setSelection: setSelected,
-        searchFilter,
+        ...props,
       }}>
       <div className='wrapper relative mt-12 @container 2xs:mt-0'>
         <TableSearchBar />

--- a/app/(components)/Shared/Table/TableColumnLabels.tsx
+++ b/app/(components)/Shared/Table/TableColumnLabels.tsx
@@ -2,6 +2,7 @@ import { useTableContext } from '@/components/Shared/Table/Table'
 import { TableVisibilities } from '@/typings/Shared/Table/Types'
 import getKeys from '@/lib/Shared/Keys'
 import Each from '@/lib/Shared/Each'
+import { twMerge } from 'tailwind-merge'
 
 /**
  * Renders the column headings of table based on the given items or provided labels.
@@ -9,14 +10,18 @@ import Each from '@/lib/Shared/Each'
  * @constructor
  */
 export default function TableColumnLabels<T>() {
-  const { labels, visibilities } = useTableContext<T>()
+  const { labels, visibilities, itemButtons } = useTableContext<T>()
   const visiblilty = (key: keyof TableVisibilities<T>) => (visibilities && visibilities.hasOwnProperty(key) ? visibilities[key] : '')
 
   return (
-    <Each
-      items={getKeys(labels)}
-      render={(value, index) => <Label key={value.toString() + index} label={labels[value]!} classes={visiblilty(value as keyof TableVisibilities<T>)} />}
-    />
+    <>
+      <Each
+        items={getKeys(labels)}
+        render={(value, index) => <Label key={value.toString() + index} label={labels[value]!} classes={visiblilty(value as keyof TableVisibilities<T>)} />}
+      />
+
+      {itemButtons && <th className={twMerge('pr-3 text-right', visibilities?.itemButtons)}>Actions</th>}
+    </>
   )
 }
 

--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -37,6 +37,7 @@ export default function TableItems<T>() {
         )}>
         <SelectCheckBox item={item} />
         <TableItem item={item} />
+        <ItemButtons item={item} />
       </motion.tr>
     ),
   })
@@ -71,4 +72,12 @@ function TableItem<T>({ item }: { item: TableElement<T> }) {
       </td>
     ),
   })
+}
+
+function ItemButtons<T>({ item }: { item: TableElement<T> }) {
+  const { itemButtons: buttons, visibilities } = useTableContext<T>()
+
+  if (!buttons) return null
+
+  return <td className={twMerge(visibilities?.itemButtons)}>{buttons(item)}</td>
 }

--- a/app/(components)/Shared/Table/TableSearchBar.tsx
+++ b/app/(components)/Shared/Table/TableSearchBar.tsx
@@ -4,7 +4,7 @@ import { useDebounce } from 'use-debounce'
 import { useTableContext } from '@/components/Shared/Table/Table'
 import TableProps, { TableElement } from '@/typings/Shared/Table/Types'
 
-export default function TableSearchBar<T>() {
+export default function TableSearchBar<T>({ className }: { className?: string }) {
   const { initialItems, searchFilter, setItems } = useTableContext<T>()
 
   const [searchValue, setSearchValue] = useState<string | undefined>(undefined)
@@ -17,7 +17,7 @@ export default function TableSearchBar<T>() {
   }, [debouncedValue])
 
   return (
-    <div className={twMerge('mb-1 hidden flex-1 items-center justify-end gap-4 @2xs:flex')}>
+    <div className={twMerge('hidden   items-center justify-end gap-4 @2xs:flex', className)}>
       <label htmlFor='table-search text-sm' className='min-w-0'>
         Suche:
       </label>

--- a/app/(components)/articles/ShowArticleHistoryButton.tsx
+++ b/app/(components)/articles/ShowArticleHistoryButton.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { twMerge } from 'tailwind-merge'
+import Link from 'next/link'
+import { CircleStackIcon } from '@heroicons/react/24/outline'
+import { useTableContext } from '@/components/Shared/Table/Table'
+
+export default function ShowArticleHistoryButton<T>() {
+  const { selection } = useTableContext<T>()
+  const ids = selection.map((s) => s.id).filter((item, index, array) => array.indexOf(item) === index)
+
+  return (
+    <Link
+      aria-disabled={selection.length === 0}
+      onClick={(e) => selection.length === 0 && e.preventDefault()}
+      href={'/article-buy-history/' + ids.join(',')}
+      className={twMerge(
+        'flex cursor-not-allowed items-center gap-2 rounded-md bg-blue-400/25 px-3 py-1.5 text-sm ring-1 ring-blue-400 hover:bg-blue-400/40 active:bg-blue-400/60 dark:bg-blue-600/25 dark:ring-blue-600 dark:hover:bg-blue-600/40 dark:active:bg-blue-600/60',
+        selection.length > 0 && 'cursor-pointer',
+      )}>
+      <CircleStackIcon width={16} height={16} />
+      Show History
+    </Link>
+  )
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -2,6 +2,7 @@ import { Article } from 'hellocash-api/typings/Article'
 import { ArticleCategory } from 'hellocash-api/typings/Category'
 import useBackend from '@/hooks/Shared/Fetch/useBackend'
 import Table from '@/components/Shared/Table/Table'
+import ShowArticleHistoryButton from '@/components/articles/ShowArticleHistoryButton'
 
 export default async function ArticlesPage() {
   const articles = await useBackend<Article[]>('/articles', { next: { revalidate: 3600, tags: ['articles'] } })
@@ -15,8 +16,9 @@ export default async function ArticlesPage() {
       <h1 className='mb-6 text-2xl font-semibold'>Articles</h1>
 
       <Table<(typeof shownArticles)[number]>
+        selectionButtons={<ShowArticleHistoryButton />}
         labels={{ id: 'ID', name: 'Name', category: 'Category' }}
-        visibilities={{ id: 'hidden min-w-16 @xl:table-cell', name: 'w-[100%]', category: 'hidden text-nowrap pr-4 text-right @3xl:table-cell' }}
+        visibilities={{ id: 'hidden min-w-16 @xl:table-cell', name: 'w-[100%]', category: 'hidden text-nowrap pr-4 text-right @3xl:table-cell whitespace-nowrap' }}
         noDefaultLabels
         items={shownArticles}
         searchFilter={['name', 'category']}

--- a/typings/Shared/Table/Types.ts
+++ b/typings/Shared/Table/Types.ts
@@ -36,6 +36,7 @@ export default interface TableProps<T> {
   searchFilter: SearchFilter<T>
   noDefaultLabels?: boolean
 
+  selectionButtons?: ReactNode | ReactNode[]
   itemButtons?: (item: TableElement<T>) => ReactNode
 }
 

--- a/typings/Shared/Table/Types.ts
+++ b/typings/Shared/Table/Types.ts
@@ -1,10 +1,11 @@
 import ReactState from '@/typings/ReactState'
+import { ReactNode } from 'react'
 
 /**
  * This interface represents the visibility-classes type that takes in each partial keys of a
  * generic type were a classes can be assigned for that key / property.
  */
-export type TableVisibilities<T> = {
+export type TableVisibilities<T> = { itemButtons?: string } & {
   [key in keyof T]?: string
 }
 
@@ -34,6 +35,8 @@ export default interface TableProps<T> {
   visibilities?: TableVisibilities<T>
   searchFilter: SearchFilter<T>
   noDefaultLabels?: boolean
+
+  itemButtons?: (item: TableElement<T>) => ReactNode
 }
 
 export interface TableContext<T> extends TableProps<T> {


### PR DESCRIPTION
The following changes are made by this Pull request:
- added `itemButtons` property to the `Table` component and `TableVisibilities`
- added rendering of `itemButtons` to each table-row
- added "Action" column-label for the `itemButtons' 

- added `selectionButtons` property to `Table` component
- rendering selectionButtons and `TableSearchBar` in the same outer-flex-box that is placed above the `Table` 
   By doing so both the selectionButtons-container and `TableSeachBar` grow equally by utilizing the flex-1 class.
- refactored `TableSearchBar` by adding className property that is used for the div that wraps the label and input
- created `ShowArticleHistoryButton` component, that is used by the `Table´ in the /articles page
   When clicked the user is redirected to the /article-buy-history/ page, that displays the history for the currently selected articles.
- added `ShowArticleHistoryButton`to the selectionButtons of the `Table` in the /articles page