### PR TITLE
Feat: Implementation of `allowSelection` Functionality + Minor Improvements

### DIFF
--- a/app/(components)/Shared/Table/Table.tsx
+++ b/app/(components)/Shared/Table/Table.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { createContext, useContext, useState } from 'react'
-import { twMerge } from 'tailwind-merge'
 import TableProps, { TableContext, TableElement } from '@/typings/Shared/Table/Types'
 import { once } from 'lodash'
 import TableColumnLabels from '@/components/Shared/Table/TableColumnLabels'
@@ -39,13 +38,7 @@ export default function Table<T>(props: TableProps<T>) {
         </div>
         <table className='w-full rounded-md'>
           <thead className='bg-gray-700 py-2 text-left dark:bg-neutral-900'>
-            <tr className='h-12 space-x-24 text-gray-100 dark:text-gray-200'>
-              <th className={twMerge('relative my-2 block h-8 min-w-16', !props.allowSelection && 'hidden')}>
-                <SelectAllCheckbox />
-              </th>
-
-              <TableColumnLabels />
-            </tr>
+            <TableColumnLabels />
           </thead>
           <motion.tbody initial='hidden' animate='visible' className='space-y-24 divide-y divide-gray-400 px-2 dark:divide-neutral-500'>
             <TableItems />
@@ -72,39 +65,4 @@ function useTableProps<T>({ items: initialItems, labels, ...props }: TableProps<
     setSelection,
     ...props,
   }
-}
-
-/**
- * Renders a checkbox that de- or selects all the items that are currently displayed in the table.
- */
-function SelectAllCheckbox<T>({ className }: { className?: string }) {
-  const { items, selection, setSelection, initialItems } = useContext<TableContext<T>>(createGenericTableContext())
-
-  return (
-    <input
-      type='checkbox'
-      className={twMerge(
-        'absolute left-4 top-1/2 -mt-2 h-4 w-4 rounded-md border-gray-300 text-indigo-600 hover:cursor-pointer focus:ring-indigo-600 dark:bg-neutral-600 dark:text-fuchsia-700 dark:checked:bg-fuchsia-700 dark:focus:ring-fuchsia-700',
-        className,
-      )}
-      checked={selection.length === initialItems.length || items.map((i) => !!selection.find((s) => s.id === i.id)).every(Boolean)}
-      onChange={() =>
-        setSelection((prev) => {
-          //* The displayed articles are a subset of the initial articles, as a search is active
-          if (items.length !== initialItems.length) {
-            //? if all the displayed articles are selected and the total-checkbox is clicked, then the displayed articles are removed from the selection.
-            if (items.map((i) => !!selection.find((s) => s.id === i.id)).every(Boolean)) {
-              return prev.filter((a) => !items.find((i) => i.id === a.id))
-            }
-
-            //? if not all the displayed articles are selected and the total-checkbox is clicked, then the displayed articles are added to the selection.
-            return [...prev, ...items.filter((i) => !prev.find((s) => s.id === i.id))]
-          }
-
-          //? When all the articles are displayed, thus no search is active, we can simply toggle the selection of all articles.
-          return prev.length === initialItems.length ? [] : initialItems
-        })
-      }
-    />
-  )
 }

--- a/app/(components)/Shared/Table/Table.tsx
+++ b/app/(components)/Shared/Table/Table.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useState } from 'react'
 import TableProps, { TableContext, TableElement } from '@/typings/Shared/Table/Types'
 import { once } from 'lodash'
-import TableColumnLabels from '@/components/Shared/Table/TableColumnLabels'
+import TableColumns from '@/components/Shared/Table/TableColumns'
 import TableItems from '@/components/Shared/Table/TableItems'
 import { motion } from 'framer-motion'
 import TableSearchBar from '@/components/Shared/Table/TableSearchBar'
@@ -38,7 +38,7 @@ export default function Table<T>(props: TableProps<T>) {
         </div>
         <table className='w-full rounded-md'>
           <thead className='bg-gray-700 py-2 text-left dark:bg-neutral-900'>
-            <TableColumnLabels />
+            <TableColumns />
           </thead>
           <motion.tbody initial='hidden' animate='visible' className='space-y-24 divide-y divide-gray-400 px-2 dark:divide-neutral-500'>
             <TableItems />

--- a/app/(components)/Shared/Table/TableColumnLabels.tsx
+++ b/app/(components)/Shared/Table/TableColumnLabels.tsx
@@ -14,7 +14,11 @@ export default function TableColumnLabels<T>() {
   const visiblilty = (key: keyof TableVisibilities<T>) => (visibilities && visibilities.hasOwnProperty(key) ? visibilities[key] : '')
 
   return (
-    <>
+    <tr className='h-12 space-x-24 text-gray-100 dark:text-gray-200'>
+      <th className={twMerge('relative my-2 block h-8 min-w-16', !allowSelection && 'hidden')}>
+        <SelectAllCheckbox />
+      </th>
+
       <Each
         items={getKeys(labels)}
         render={(value, index) => (
@@ -23,7 +27,7 @@ export default function TableColumnLabels<T>() {
       />
 
       {itemButtons && <th className={twMerge('pr-3 text-right', visibilities?.itemButtons)}>Actions</th>}
-    </>
+    </tr>
   )
 }
 
@@ -32,5 +36,40 @@ function Label({ label, classes }: { label: string; classes?: string }) {
     <th key={label.toString() + 'headers'} className={classes}>
       {label.toString()}
     </th>
+  )
+}
+
+/**
+ * Renders a checkbox that de- or selects all the items that are currently displayed in the table.
+ */
+function SelectAllCheckbox<T>({ className }: { className?: string }) {
+  const { items, selection, setSelection, initialItems } = useTableContext<T>()
+
+  return (
+    <input
+      type='checkbox'
+      className={twMerge(
+        'absolute left-4 top-1/2 -mt-2 h-4 w-4 rounded-md border-gray-300 text-indigo-600 hover:cursor-pointer focus:ring-indigo-600 dark:bg-neutral-600 dark:text-fuchsia-700 dark:checked:bg-fuchsia-700 dark:focus:ring-fuchsia-700',
+        className,
+      )}
+      checked={selection.length === initialItems.length || items.map((i) => !!selection.find((s) => s.id === i.id)).every(Boolean)}
+      onChange={() =>
+        setSelection((prev) => {
+          //* The displayed articles are a subset of the initial articles, as a search is active
+          if (items.length !== initialItems.length) {
+            //? if all the displayed articles are selected and the total-checkbox is clicked, then the displayed articles are removed from the selection.
+            if (items.map((i) => !!selection.find((s) => s.id === i.id)).every(Boolean)) {
+              return prev.filter((a) => !items.find((i) => i.id === a.id))
+            }
+
+            //? if not all the displayed articles are selected and the total-checkbox is clicked, then the displayed articles are added to the selection.
+            return [...prev, ...items.filter((i) => !prev.find((s) => s.id === i.id))]
+          }
+
+          //? When all the articles are displayed, thus no search is active, we can simply toggle the selection of all articles.
+          return prev.length === initialItems.length ? [] : initialItems
+        })
+      }
+    />
   )
 }

--- a/app/(components)/Shared/Table/TableColumnLabels.tsx
+++ b/app/(components)/Shared/Table/TableColumnLabels.tsx
@@ -10,14 +10,16 @@ import { twMerge } from 'tailwind-merge'
  * @constructor
  */
 export default function TableColumnLabels<T>() {
-  const { labels, visibilities, itemButtons } = useTableContext<T>()
+  const { labels, visibilities, itemButtons, allowSelection } = useTableContext<T>()
   const visiblilty = (key: keyof TableVisibilities<T>) => (visibilities && visibilities.hasOwnProperty(key) ? visibilities[key] : '')
 
   return (
     <>
       <Each
         items={getKeys(labels)}
-        render={(value, index) => <Label key={value.toString() + index} label={labels[value]!} classes={visiblilty(value as keyof TableVisibilities<T>)} />}
+        render={(value, index) => (
+          <Label key={value.toString() + index} label={labels[value]!} classes={`${visiblilty(value as keyof TableVisibilities<T>)} ${index === 0 && !allowSelection && 'pl-4'}`} />
+        )}
       />
 
       {itemButtons && <th className={twMerge('pr-3 text-right', visibilities?.itemButtons)}>Actions</th>}

--- a/app/(components)/Shared/Table/TableColumns.tsx
+++ b/app/(components)/Shared/Table/TableColumns.tsx
@@ -22,7 +22,11 @@ export default function TableColumns<T>() {
       <Each
         items={getKeys(labels)}
         render={(value, index) => (
-          <Label key={value.toString() + index} label={labels[value]!} classes={`${visiblilty(value as keyof TableVisibilities<T>)} ${index === 0 && !allowSelection && 'pl-4'}`} />
+          <Label
+            key={value.toString() + index}
+            label={labels[value]!}
+            classes={twMerge('pr-2', visiblilty(value as keyof TableVisibilities<T>), index === 0 && !allowSelection && 'pl-4')}
+          />
         )}
       />
 

--- a/app/(components)/Shared/Table/TableColumns.tsx
+++ b/app/(components)/Shared/Table/TableColumns.tsx
@@ -9,7 +9,7 @@ import { twMerge } from 'tailwind-merge'
  * In case no labels are provided, the property-keys of the items are used as the column headings.
  * @constructor
  */
-export default function TableColumnLabels<T>() {
+export default function TableColumns<T>() {
   const { labels, visibilities, itemButtons, allowSelection } = useTableContext<T>()
   const visiblilty = (key: keyof TableVisibilities<T>) => (visibilities && visibilities.hasOwnProperty(key) ? visibilities[key] : '')
 

--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -80,5 +80,5 @@ function ItemButtons<T>({ item }: { item: TableElement<T> }) {
 
   if (!buttons) return null
 
-  return <td className={twMerge(visibilities?.itemButtons)}>{buttons(item)}</td>
+  return <td className={twMerge(visibilities?.itemButtons)}>{buttons({ item })}</td>
 }

--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -68,7 +68,7 @@ function TableItem<T>({ item }: { item: TableElement<T> }) {
   return Each({
     items: getKeys(labels),
     render: (key, index) => (
-      <td key={item.id.toString() + key.toString() + index} className={twMerge(visibilities ? visibilities[key] : '', !allowSelection && index === 0 && 'pl-4')}>
+      <td key={item.id.toString() + key.toString() + index} className={twMerge('pr-2', visibilities ? visibilities[key] : '', !allowSelection && index === 0 && 'pl-4')}>
         {item[key]}
       </td>
     ),

--- a/app/(components)/Shared/Table/TableItems.tsx
+++ b/app/(components)/Shared/Table/TableItems.tsx
@@ -45,9 +45,10 @@ export default function TableItems<T>() {
 
 function SelectCheckBox<T>({ item }: { item: TableElement<T> }) {
   const { isSelected, toggleSelection } = useTableSelection<T>()
+  const { allowSelection } = useTableContext<T>()
 
   return (
-    <td className='relative min-w-12'>
+    <td className={twMerge('relative min-w-12', !allowSelection && 'hidden')}>
       {isSelected(item) && <div className='absolute inset-y-0 left-0 w-0.5 bg-indigo-600 dark:bg-fuchsia-700' />}
 
       <input
@@ -62,12 +63,12 @@ function SelectCheckBox<T>({ item }: { item: TableElement<T> }) {
 }
 
 function TableItem<T>({ item }: { item: TableElement<T> }) {
-  const { labels, visibilities } = useTableContext<T>()
+  const { labels, visibilities, allowSelection } = useTableContext<T>()
 
   return Each({
     items: getKeys(labels),
     render: (key, index) => (
-      <td key={item.id.toString() + key.toString() + index} className={twMerge(visibilities ? visibilities[key] : '')}>
+      <td key={item.id.toString() + key.toString() + index} className={twMerge(visibilities ? visibilities[key] : '', !allowSelection && index === 0 && 'pl-4')}>
         {item[key]}
       </td>
     ),

--- a/app/(components)/Shared/Table/TableSelectionButtons.tsx
+++ b/app/(components)/Shared/Table/TableSelectionButtons.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useTableContext } from '@/components/Shared/Table/Table'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Renders the selection-buttons inside a flex-container, that has an opacity of 25% when no items are selected and is hidden when the selection is not allowed / disabled.
+ * @param className Additional classes that are applied to the flex-container.
+ * @description Default classes: 'flex flex-1 flex-wrap gap-2'
+ */
+export default function TableSelectionButtons<T>({ className }: { className?: string }) {
+  const { selection, selectionButtons, allowSelection } = useTableContext<T>()
+  return <div className={twMerge('flex flex-1 flex-wrap gap-2', selection.length === 0 && 'opacity-25', !allowSelection && 'hidden', className)}>{selectionButtons}</div>
+}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -16,9 +16,10 @@ export default async function ArticlesPage() {
       <h1 className='mb-6 text-2xl font-semibold'>Articles</h1>
 
       <Table<(typeof shownArticles)[number]>
+        allowSelection={true}
         selectionButtons={<ShowArticleHistoryButton />}
         labels={{ id: 'ID', name: 'Name', category: 'Category' }}
-        visibilities={{ id: 'hidden min-w-16 @xl:table-cell', name: 'w-[100%]', category: 'hidden text-nowrap pr-4 text-right @3xl:table-cell whitespace-nowrap' }}
+        visibilities={{ id: 'hidden min-w-24 @xl:table-cell', name: 'w-[100%]', category: 'hidden text-nowrap pr-4 text-right @3xl:table-cell whitespace-nowrap' }}
         noDefaultLabels
         items={shownArticles}
         searchFilter={['name', 'category']}

--- a/hooks/Table/useTableSelection.ts
+++ b/hooks/Table/useTableSelection.ts
@@ -3,10 +3,11 @@
 import { useTableContext } from '@/components/Shared/Table/Table'
 
 export default function useTableSelection<T>() {
-  const { items, selection, setSelection } = useTableContext<T>()
+  const { items, selection, setSelection, allowSelection } = useTableContext<T>()
 
   const isSelected = (item: (typeof items)[number]) => !!selection.find((i) => i.id === item.id)
-  const toggleSelection = (item: (typeof items)[number]) => () => setSelection((prev) => (isSelected(item) ? prev.filter((a) => a.id !== item.id) : [...prev, item]))
+  const toggleSelection = (item: (typeof items)[number]) => () =>
+    allowSelection ? setSelection((prev) => (isSelected(item) ? prev.filter((a) => a.id !== item.id) : [...prev, item])) : null
 
   return { isSelected, toggleSelection }
 }

--- a/typings/Shared/Table/Types.ts
+++ b/typings/Shared/Table/Types.ts
@@ -36,6 +36,7 @@ export default interface TableProps<T> {
   searchFilter: SearchFilter<T>
   noDefaultLabels?: boolean
 
+  allowSelection?: boolean
   selectionButtons?: ReactNode | ReactNode[]
   itemButtons?: (item: TableElement<T>) => ReactNode
 }

--- a/typings/Shared/Table/Types.ts
+++ b/typings/Shared/Table/Types.ts
@@ -38,7 +38,7 @@ export default interface TableProps<T> {
 
   allowSelection?: boolean
   selectionButtons?: ReactNode | ReactNode[]
-  itemButtons?: (item: TableElement<T>) => ReactNode
+  itemButtons?: ({ item }: { item: TableElement<T> }) => ReactNode
 }
 
 export interface TableContext<T> extends TableProps<T> {


### PR DESCRIPTION
The `allowSelection` property brings more functionalities to the generic Table, as it controls whether the items of the table can be selected, by clicking on the row, row-checkbox or the select-all-checkbox. When the allowSelection property is set to false, then the select-functionality should be disabled. 

The following changes are made in this Pull request:
- added `allowSelection` property to TableProps
- disabled table-row checkbox and select-all check when the allowSelection is set to false
   In other words, when the allowSelection property is set to false, then the select-all-checkbox is hidden and the select-checkbox for each item is hidden as well. Additionally, when the allowSelection property is set to false, then the first column and property of an item receives a padding-left of 4, so that it looks visually more appealing. 
- disabled `toggleSelection` helper-function from `useTableSelection` hook conditionally
   When the `allowSelection` property is set to false, then calling the `toggleSelection` function won't change the selection. 
- externalized rendering of selection-buttons to `TableSelectionButtons` component
   In doing so the selection-buttons are now also conditionally rendered. Thus, when the allowSelection property is set to false, then the selection-buttons are not disabled.

#### Minor Changes 
- improved code-base of the `Table` component
   Moved the paring procedure of the table-props to context-props into a local hook.
- moved the `SelectAllCheckbox` from the `Table` component to the `TableColumns` component
- renamed the `TableColumnsLabel` component to `TableColumns`
   The reason for this change is that, this component now renders also renders the SelectAllCheckbox, that was moved from the Table component to the TableColumns component. Therefore, the component no longer renders only the labels but instead all the labels of the Table.
- added `pr-4` to all columns and item-fields (`td`) to ensure that there is always a gap between columns
   However, this can be removed by setting `pr-0` using the visibility classes
- enabled the Table selection functionality by setting the allowSelection to true in the `/articles` page
- updated the properties of the function that is to be provided to the `itemButtons` property of the `Table`
   instead of providing the item as a simple argument it is now provided inside an object, so that the `item` can be desctructured. This is useful, since components can be directly supplied to the `itemButtons` property.
   For example:
   `function ExampleButton<T>({item}: {item: TableElement<T>}) {....}`

   `<Table .... itemButtons={ExampleButton} />`