### PR TITLE
Feat: Implementation of a Customers page (`/customers`)

### DIFF
--- a/app/(components)/customers/CustomerHistoryButton.tsx
+++ b/app/(components)/customers/CustomerHistoryButton.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { TableElement } from '@/typings/Shared/Table/Types'
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+import { CircleStackIcon } from '@heroicons/react/24/outline'
+
+export default function CustomerHistoryButton<T>({ item }: { item: TableElement<T> }) {
+  return (
+    <Link
+      href={`/customer-history/${item.id}/`}
+      className={twMerge(
+        'flex cursor-pointer items-center gap-2 rounded-md bg-blue-400/25 px-3 py-1.5 text-sm ring-1 ring-blue-400 hover:bg-blue-400/40 active:bg-blue-400/60 dark:bg-blue-600/25 dark:ring-blue-600 dark:hover:bg-blue-600/40 dark:active:bg-blue-600/60',
+      )}>
+      <CircleStackIcon width={16} height={16} />
+      Show History
+    </Link>
+  )
+}

--- a/app/(components)/root/NavigationBar/SideBar.tsx
+++ b/app/(components)/root/NavigationBar/SideBar.tsx
@@ -24,6 +24,11 @@ export default async function SideBar() {
         icon: 'TableCellsIcon',
         href: '/articles',
       },
+      {
+        name: 'Customers',
+        icon: 'UsersIcon',
+        href: '/customers',
+      },
     ],
   }
   const managementElements: SideElementProps[] = [

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,0 +1,13 @@
+import getHellocashAPI from '@/lib/Shared/HelloCash'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export async function GET(req: Request) {
+  const params = new URL(req.url).searchParams
+  const limit = parseInt(params?.get('limit')?.toString() ?? '-1')
+
+  const { getCustomers } = getHellocashAPI()
+  const customers = await getCustomers(limit)
+
+  return NextResponse.json(customers)
+}

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,0 +1,36 @@
+import Table from '@/components/Shared/Table/Table'
+import { Customer } from 'hellocash-api/typings/Customer'
+import CustomerHistoryButton from '@/components/customers/CustomerHistoryButton'
+import useBackend from '@/hooks/Shared/Fetch/useBackend'
+
+export default async function CustomerPage() {
+  let baseCustomers = await useBackend<Customer[]>('/customers?limit=-1', { next: { revalidate: 60, tags: ['customers'] } })
+
+  type ExtendedCustomer = Customer & { name: string }
+  const modifiedCustomers = baseCustomers.map((c: Customer): ExtendedCustomer => {
+    const company = !!c.company && c.company !== 'null' ? c.company : ''
+
+    return { ...c, name: `${c.firstName} ${c.lastName} ${company}`.trim() }
+  })
+
+  return (
+    <div>
+      <h1 className='mb-6 text-2xl font-semibold'>Customers</h1>
+
+      <Table<ExtendedCustomer>
+        itemButtons={CustomerHistoryButton}
+        items={modifiedCustomers}
+        noDefaultLabels
+        searchFilter={['name', 'postCode', 'street', 'phone', 'email', 'city', 'company', 'country']}
+        labels={{ salutation: 'Anrede', name: 'Name', street: 'Straße', postCode: 'Postleitzahl' }}
+        visibilities={{
+          salutation: 'min-w-24 hidden @md:table-cell',
+          name: 'w-full text-sm @xs:text-base',
+          street: 'hidden @xl:table-cell',
+          postCode: 'text-center hidden @3xl:table-cell',
+          itemButtons: 'min-w-36 text-center',
+        }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
The following changes were made in this Pull request:
- created `/customers` api endpoint that returns a requested amount of customers, to allow for easy re validation
- created `CustomerHistoryButton` component that redirects to the customer-history-page for a given customer
- created `/customers` page that shows all the customers using the generic-Table component
- added `/customers` page to the `SideBar`