### PR TITLE
Refactor: Improvement of Children Rendering in the Root Layout 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={inter.className}>
         <AuthProvider>
           <SideBar />
-          <div className={structureClasses('relative px-4 py-4 text-gray-700 dark:text-gray-200 lg:ml-72', lightBackground, darkBackground)}>{children}</div>
+          {/*  Children Container takes up the full height and width of the remaining space*/}
+          <div className={structureClasses('fixed inset-0 top-14 flex flex-col px-4 py-4 text-gray-700 dark:text-gray-200 lg:inset-y-0 lg:ml-72', lightBackground, darkBackground)}>
+            <div className='relative h-full w-full'>{children}</div>
+          </div>
         </AuthProvider>
         <ToastContainer position='top-right' autoClose={3000} stacked />
       </body>


### PR DESCRIPTION
### The following change was made in this Pull request:

Changed the structure for rendering the children elements in the root-layout.

The reason for this change is that, the container that wrapped the children did not "stretch" / cover the remaining space, at least its height didn't stretch.

Therefore the parent-div classes were changed to be fixed and the top, left properties were set to fill up the remaining space.

In order to provide a relative element for all the pages that are displayed a div element was placed inside of the fixed-container that wraps the children elements. Again the reason for this nested relative element is that elements inside of a page can placed with position absolute within the pages dimensions. In order to not loose the "stretching" behavior the relative-container has the `w-full` and `h-full` classes.

This way, the contents of the pages could take up the entire page-space using `h-full`.


#### Note
Some pages currently wrap their contents inside of a div. These pages will not be able to utilize the `h-full` class inside that container, unless the div-wrapper "stretches" again to the remaining-space using `h-full`.