### PR TITLE
Feat: Implementation of Unified and Traceable Logs using Winston

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+/logs

--- a/lib/Shared/Logs/LevelOnlyFormat.ts
+++ b/lib/Shared/Logs/LevelOnlyFormat.ts
@@ -1,0 +1,10 @@
+import { format } from 'winston'
+import { LoggingLevels } from '@/lib/Shared/Logs/Logger'
+
+export default function LevelOnlyFormat(level: LoggingLevels) {
+  const filter = format((log) => {
+    return log.level === level ? log : false
+  })
+
+  return filter()
+}

--- a/lib/Shared/Logs/Logger.ts
+++ b/lib/Shared/Logs/Logger.ts
@@ -1,0 +1,92 @@
+'use server'
+import * as winston from 'winston'
+import { createLogger } from 'winston'
+import { CONSOLE_FORMAT } from '@/lib/Shared/Logs/LoggerFormats'
+import { existsSync, mkdirSync } from 'node:fs'
+import { createFileTransport } from '@/lib/Shared/Logs/LoggerTransports'
+
+const isSilent = !!process.env.WINSTON_SILENT
+
+// Create the logs directory if it doesn't exist
+existsSync('./logs') || mkdirSync('./logs')
+
+const logger = createLogger({
+  handleExceptions: true,
+  exitOnError: false,
+  transports: [
+    createFileTransport('error', { dir: 'logs', disabled: isSilent, levelOnly: true }),
+    createFileTransport('warn', { dir: 'logs', disabled: isSilent, levelOnly: true }),
+    createFileTransport('info', { dir: 'logs', disabled: isSilent, levelOnly: true }),
+    createFileTransport('debug', { dir: 'logs', disabled: isSilent, levelOnly: true }),
+    createFileTransport('verbose', { dir: 'logs', disabled: isSilent, levelOnly: true }),
+    createFileTransport('silly', { dir: 'logs', disabled: isSilent, overrideFileName: 'logs' }),
+
+    new winston.transports.Console({ format: CONSOLE_FORMAT, level: 'silly' }),
+  ],
+})
+
+export type LoggingLevels = 'error' | 'warn' | 'info' | 'debug' | 'verbose' | 'silly'
+
+interface LoggingProps {
+  message: string | number | object
+  args: any
+}
+
+async function logMessage(level: LoggingLevels, message: LoggingProps['message'], args?: any) {
+  /** Simplifies the message and the args to be logged
+   *  In case the message is an object, it will be stringified
+   *  Each arg that is no object will be added with a space to the message
+   *  Each arg that is an object will be stringified and added with a new line before and after
+   * */
+  const simplfyMessage = () => {
+    if (typeof message === 'object') message = '\n' + JSON.stringify(message, null, 2)
+    if (args && args.length > 0) {
+      message += ' ' // Add a space between the message and the args
+      args.forEach((arg: any) => (typeof arg === 'object' ? (message += `\n${JSON.stringify(arg, null, 2)}\n`) : (message += arg.toString() + ' ')))
+    }
+    return message.toString()
+  }
+
+  // @ts-ignore
+  logger[level](simplfyMessage())
+}
+
+/** Logs a given message with the level 'error' using winston
+ *  @description Works both on the client and server side.
+ *  Note, when used on the client side, the log-functions cannot be called when the component is initially rendered. Thus, must be called in useEffect or other functions.
+ *  @param message - The message to be logged, can be a string, number or object
+ *  @param args - Additional arguments to be logged, which can be again strings, numbers or objects
+ */
+export const logError = async (message: LoggingProps['message'], ...args: LoggingProps['args']) => logMessage('error', message, args)
+
+/** Logs a given message with the level 'warn' using winston
+ *  @description Works both on the client and server side
+ *  Note, when used on the client side, the log-functions cannot be called when the component is initially rendered. Thus, must be called in useEffect or other functions.
+ *  @param message - The message to be logged, can be a string, number or object
+ *  @param args - Additional arguments to be logged, which can be again strings, numbers or objects
+ */
+export const logWarning = async (message: LoggingProps['message'], ...args: LoggingProps['args']) => logMessage('warn', message, args)
+
+/** Logs a given message with the level 'info' using winston
+ *  @description Works both on the client and server side
+ *  Note, when used on the client side, the log-functions cannot be called when the component is initially rendered. Thus, must be called in useEffect or other functions.
+ *  @param message - The message to be logged, can be a string, number or object
+ *  @param args - Additional arguments to be logged, which can be again strings, numbers or objects
+ */
+export const logInfo = async (message: LoggingProps['message'], ...args: LoggingProps['args']) => logMessage('info', message, args)
+
+/** Logs a given message with the level 'debug' using winston
+ *  @description Works both on the client and server side
+ *  Note, when used on the client side, the log-functions cannot be called when the component is initially rendered. Thus, must be called in useEffect or other functions.
+ *  @param message - The message to be logged, can be a string, number or object
+ *  @param args - Additional arguments to be logged, which can be again strings, numbers or objects
+ */
+export const logDebug = async (message: LoggingProps['message'], ...args: LoggingProps['args']) => logMessage('debug', message, args)
+
+/** Logs a given message with the level 'verbose' using winston
+ *  @description Works both on the client and server side
+ *  Note, when used on the client side, the log-functions cannot be called when the component is initially rendered. Thus, must be called in useEffect or other functions.
+ *  @param message - The message to be logged, can be a string, number or object
+ *  @param args - Additional arguments to be logged, which can be again strings, numbers or objects
+ */
+export const logVerbose = async (message: LoggingProps['message'], ...args: LoggingProps['args']) => logMessage('verbose', message, args)

--- a/lib/Shared/Logs/LoggerFormats.ts
+++ b/lib/Shared/Logs/LoggerFormats.ts
@@ -1,0 +1,30 @@
+import { format } from 'logform'
+import combine = format.combine
+import colorize = format.colorize
+import printf = format.printf
+import padLevels = format.padLevels
+
+export const FILE_FORMAT = combine(
+  padLevels(),
+  printf(({ level, message, label }) => {
+    const date = new Date(Date.now())
+
+    const timestamp =
+      date
+        .toLocaleDateString('de')
+        .split('.')
+        .map((seg) => (seg.length >= 2 ? seg : '0' + seg))
+        .join('.') +
+      ' ' +
+      date.toLocaleTimeString('de')
+
+    return `[${timestamp}] [${level.toUpperCase()}]: ${message}`
+  }),
+)
+
+export const CONSOLE_FORMAT = combine(
+  colorize(),
+  printf(({ level, message, label, timestamp }) => {
+    return `[${level}]: ${message}`
+  }),
+)

--- a/lib/Shared/Logs/LoggerTransports.ts
+++ b/lib/Shared/Logs/LoggerTransports.ts
@@ -1,0 +1,20 @@
+import { LoggingLevels } from '@/lib/Shared/Logs/Logger'
+import * as winston from 'winston'
+import { format } from 'winston'
+import LevelOnlyFormat from '@/lib/Shared/Logs/LevelOnlyFormat'
+import { FILE_FORMAT } from '@/lib/Shared/Logs/LoggerFormats'
+import combine = format.combine
+
+export function createFileTransport(level: LoggingLevels, options?: { dir?: string; overrideFileName?: string; levelOnly?: boolean; disabled?: boolean }) {
+  let { dir, overrideFileName, levelOnly, disabled } = options ?? {}
+
+  if (dir?.startsWith('/')) dir = dir.substring(1)
+  if (dir && !dir.endsWith('/')) dir = dir + '/'
+
+  return new winston.transports.File({
+    filename: `./${dir}${overrideFileName ?? level}.log`,
+    level,
+    format: levelOnly ? combine(FILE_FORMAT, LevelOnlyFormat(level)) : FILE_FORMAT,
+    silent: disabled,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tailwind-merge": "^2.1.0",
     "use-debounce": "^10.0.0",
     "uuid": "^9.0.1",
+    "winston": "^3.13.0",
     "woocommerce-utils": "1.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,20 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@emnapi/runtime@^0.45.0":
   version "0.45.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-0.45.0.tgz#e754de04c683263f34fd0c7f32adfe718bbe4ddd"
@@ -473,6 +487,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
 "@types/uuid@^9.0.7":
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
@@ -707,6 +726,11 @@ ast-types-flow@^0.0.8:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
 
+async@^3.2.3:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
+  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
+
 asynciterator.prototype@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz#8c5df0514936cdd133604dfcc9d3fb93f09b2b62"
@@ -881,6 +905,13 @@ clsx@^2.1.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
   integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
+color-convert@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -888,18 +919,31 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.9.0:
+color-string@^1.6.0, color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 color@^4.2.3:
   version "4.2.3"
@@ -908,6 +952,14 @@ color@^4.2.3:
   dependencies:
     color-convert "^2.0.1"
     color-string "^1.9.0"
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 commander@^4.0.0:
   version "4.1.1"
@@ -1095,6 +1147,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encoding@0.1.12:
   version "0.1.12"
@@ -1450,6 +1507,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "http://10.0.100.10:4873/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
@@ -1501,6 +1563,11 @@ flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -1948,6 +2015,11 @@ is-shared-array-buffer@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -2085,6 +2157,11 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 language-subtag-registry@^0.3.20:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
@@ -2136,6 +2213,18 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.3.2, logform@^2.4.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.6.0.tgz#8c82a983f05d6eaeb2d75e3decae7a768b2bf9b5"
+  integrity sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==
+  dependencies:
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -2450,6 +2539,13 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
+
 openid-client@^5.4.0:
   version "5.6.4"
   resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.6.4.tgz#b2c25e6d5338ba3ce00e04341bb286798a196177"
@@ -2724,7 +2820,7 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-readable-stream@^3.6.0:
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "http://10.0.100.10:4873/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -2849,6 +2945,11 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.5"
     get-intrinsic "^1.2.2"
     is-regex "^1.1.4"
+
+safe-stable-stringify@^2.3.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
@@ -2985,6 +3086,11 @@ sparse-bitfield@^3.0.3:
   integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
   dependencies:
     memory-pager "^1.0.2"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 streamsearch@^1.1.0:
   version "1.1.0"
@@ -3155,6 +3261,11 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3187,6 +3298,11 @@ tr46@^4.1.1:
   integrity sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==
   dependencies:
     punycode "^2.3.0"
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-api-utils@^1.0.1:
   version "1.0.3"
@@ -3401,6 +3517,32 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winston-transport@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.7.0.tgz#e302e6889e6ccb7f383b926df6936a5b781bd1f0"
+  integrity sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.13.0.tgz#e76c0d722f78e04838158c61adc1287201de7ce3"
+  integrity sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.7.0"
 
 woocommerce-utils@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### The following changes are made in this Pull request:
- installed `winston@3.13.0` package
- created `levelOnlyFormat` function / module
   This function can be used as a Format element in the configuration of winston. In other words, it can be used as any regular format element of winston inside the `combine` function.

   This format will only "allow" / pass through a given level. That means, that the messages / logs of other levels are not going to be logged, when this format is applied. This can be useful, when the logs are saved in an file and a specific level that is somewhere in middle shall be saved in a file without any other levels.
- created two custom winston Formats 
   Created the following two Formats:
   - FILE_FORMAT
   - CONSOLE_FORMAT

   The difference is that the console format only prints the level and message, while the file format adds a padding to the level and prints the timestamp of the log as well.
- created `createFileTransport` function / module
   This module exports a single function ´createFileTransport` which creates a winston-file-transport.

   With the help of this function it is simple to create a new transport, that saves the logs in a given directory for a given level, where the filename is level.log. It also allows for customization, like whether or not the file is stored in a directory, whether it saves only one specific level, whether the file-transport is disabled and finally whether the file-name that is set by the function (level.log), shall be overridden with a custom filename.
- created `Logger` module
   This module creates a new winston-logger and sets up the file-transports and console-transport. It then also export a few logging functions for each log-level that can be used both on the server and client-side.
    > However, these log-functions cannot be called on the initial render of a client-side component (throws an error).

   The following logging-functions are exported:
   - `logError`
   - `logWarning`
   - `logInfo`
   - `logDebug`
   - `logVerbose`
- added the /logs directory to the `.gitignore` file